### PR TITLE
Implement inline scheduling handoff and related optimizations

### DIFF
--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -1256,6 +1256,23 @@ behavior of earlier flags.
     > properly in OTP. When these bugs have been fixed, this flag will be
     > removed.
 
+  - **`+sih true|migrate|false`{: #+sih }** - Sets the scheduler inline handoff
+    mode. By default (`true`) inline handoff is enabled. When a running process
+    wakes another process up by sending it a message, the woken process is
+    placed on the current scheduler's run queue instead of being scheduled on
+    another scheduler, and is run inline using the remaining part of the waking
+    process' time slice when the waking process schedules out (for example, by
+    blocking in a `receive`). This improves latency and cache locality for
+    synchronous communication patterns such as
+    [`gen_server:call/2,3`](`gen_server:call/2`), at no extra reduction cost
+    since the woken process runs on reductions the waking process was already
+    entitled to.
+
+    When set to `migrate`, the woken process is still moved to the waking
+    process' run queue (avoiding an inter-scheduler wakeup), but is not run
+    inline and instead gets a time slice of its own. When set to `false`, a
+    woken process is scheduled as usual on its assigned run queue.
+
   - **`+spp Bool`{: #+spp }** - Sets default scheduler hint for port
     parallelism. If set to `true`, the virtual machine schedules port tasks when
     it improves parallelism in the system. If set to `false`, the virtual

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -651,7 +651,8 @@ atom runtime
 atom safe
 atom save_calls
 atom sbct
-atom scheduler 
+atom sched_inline_handoffs
+atom scheduler
 atom scheduler_id
 atom scheduler_wall_time
 atom scheduler_wall_time_all

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -4228,6 +4228,22 @@ BIF_RETTYPE statistics_1(BIF_ALIST_1)
 	hp = HAlloc(BIF_P, 3);
 	res = TUPLE2(hp, cs, SMALL_ZERO);
 	BIF_RET(res);
+    } else if (BIF_ARG_1 == am_sched_inline_handoffs) {
+	Uint64 arms = 0, picks = 0;
+	Uint hsz = 3;
+	Eterm at, pt;
+	int ix;
+	for (ix = 0; ix < erts_no_schedulers; ix++) {
+	    arms += ERTS_SCHEDULER_IX(ix)->handoff.count;
+	    picks += ERTS_SCHEDULER_IX(ix)->handoff.picks;
+	}
+	erts_bld_uint64(NULL, &hsz, arms);
+	erts_bld_uint64(NULL, &hsz, picks);
+	hp = HAlloc(BIF_P, hsz);
+	at = erts_bld_uint64(&hp, NULL, arms);
+	pt = erts_bld_uint64(&hp, NULL, picks);
+	res = TUPLE2(hp, at, pt);
+	BIF_RET(res);
     } else if (BIF_ARG_1 == am_garbage_collection) {
 	res = erts_gc_info_request(BIF_P);
 	if (is_non_value(res))

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -674,6 +674,8 @@ __decl_noreturn void __noreturn  erts_usage(void)
 		 ERTS_SCHED_THREAD_MIN_STACK_SIZE,
 		 ERTS_SCHED_THREAD_MAX_STACK_SIZE,
                  ERTS_DEFAULT_DIO_SCHED_STACK_SIZE);
+    erts_fprintf(stderr, "-sih Bool      enable or disable scheduler inline handoff of\n");
+    erts_fprintf(stderr, "               processes woken by message sends (default true)\n");
     erts_fprintf(stderr, "-spp Bool      set port parallelism scheduling hint\n");
     erts_fprintf(stderr, "-S n1:n2       set number of schedulers (n1), and number of\n");
     erts_fprintf(stderr, "               schedulers online (n2); maximum for both\n");
@@ -2040,6 +2042,19 @@ erl_start(int argc, char **argv)
                 /* ignore argument, eager check io no longer used */
                 arg = get_arg(sub_param+4, argv[i+1], &i);
             }
+	    else if (has_prefix("ih", sub_param)) {
+		arg = get_arg(sub_param+2, argv[i+1], &i);
+		if (sys_strcmp("true", arg) == 0)
+		    erts_sched_inline_handoff = 1;
+		else if (sys_strcmp("false", arg) == 0)
+		    erts_sched_inline_handoff = 0;
+		else {
+		    erts_fprintf(stderr,
+				 "bad scheduler inline handoff value '%s'\n",
+				 arg);
+		    erts_usage();
+		}
+	    }
 	    else if (has_prefix("pp", sub_param)) {
 		arg = get_arg(sub_param+2, argv[i+1], &i);
 		if (sys_strcmp(arg, "true") == 0)

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -674,8 +674,9 @@ __decl_noreturn void __noreturn  erts_usage(void)
 		 ERTS_SCHED_THREAD_MIN_STACK_SIZE,
 		 ERTS_SCHED_THREAD_MAX_STACK_SIZE,
                  ERTS_DEFAULT_DIO_SCHED_STACK_SIZE);
-    erts_fprintf(stderr, "-sih Bool      enable or disable scheduler inline handoff of\n");
-    erts_fprintf(stderr, "               processes woken by message sends (default true)\n");
+    erts_fprintf(stderr, "-sih val       scheduler inline handoff of processes woken by\n");
+    erts_fprintf(stderr, "               message sends; valid values are:\n");
+    erts_fprintf(stderr, "               true | migrate | false (default true)\n");
     erts_fprintf(stderr, "-spp Bool      set port parallelism scheduling hint\n");
     erts_fprintf(stderr, "-S n1:n2       set number of schedulers (n1), and number of\n");
     erts_fprintf(stderr, "               schedulers online (n2); maximum for both\n");
@@ -2045,9 +2046,11 @@ erl_start(int argc, char **argv)
 	    else if (has_prefix("ih", sub_param)) {
 		arg = get_arg(sub_param+2, argv[i+1], &i);
 		if (sys_strcmp("true", arg) == 0)
-		    erts_sched_inline_handoff = 1;
+		    erts_sched_inline_handoff = ERTS_SCHED_HANDOFF_INLINE;
+		else if (sys_strcmp("migrate", arg) == 0)
+		    erts_sched_inline_handoff = ERTS_SCHED_HANDOFF_MIGRATE;
 		else if (sys_strcmp("false", arg) == 0)
-		    erts_sched_inline_handoff = 0;
+		    erts_sched_inline_handoff = ERTS_SCHED_HANDOFF_OFF;
 		else {
 		    erts_fprintf(stderr,
 				 "bad scheduler inline handoff value '%s'\n",

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -453,10 +453,16 @@ queue_messages(Eterm from,
 	erts_proc_unlock(receiver, ERTS_PROC_LOCK_MSGQ);
     }
 
+    /*
+     * A wakeup caused by a local message send makes the receiver
+     * eligible for inline scheduling handoff...
+     */
+    erts_sched_handoff_hint_begin();
     if (last == &first->next)
         erts_proc_notify_new_message(receiver, receiver_locks);
     else
         erts_proc_notify_new_sig(receiver, state, ERTS_PSFLG_ACTIVE);
+    erts_sched_handoff_hint_end();
 }
 
 static ERTS_INLINE

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -2271,11 +2271,18 @@ erts_proc_sig_send_altact_msg(Process *c_p, Eterm from, Eterm to, Eterm msg, Ete
     itpl[0] = make_arityval(ix);
     ERL_MESSAGE_FROM(mp) = make_tuple(itpl);
 
+    /*
+     * A wakeup caused by a local alternate-action message send (e.g.
+     * the alias reply of a gen_server:call) makes the receiver
+     * eligible for inline scheduling handoff...
+     */
+    erts_sched_handoff_hint_begin();
     if (!proc_queue_signal(&c_p->common, from, pid, (ErtsSignal *) mp, 0,
                            ERTS_SIG_Q_OP_ALTACT_MSG)) {
         mp->next = NULL;
         erts_cleanup_messages(mp);
     }
+    erts_sched_handoff_hint_end();
 
     ERTS_LC_ASSERT(!(rp_locks & ERTS_PROC_LOCKS_ALL_MINOR));
     if (c_p != rp && rp_locks)

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -2949,12 +2949,19 @@ erts_proc_sig_send_demonitor(ErtsPTabElementCommon *sender, Eterm from,
     sig->common.tag = ERTS_PROC_SIG_MAKE_TAG(ERTS_SIG_Q_OP_DEMONITOR,
                                              type, 0);
 
+    /*
+     * Monitor and demonitor signals are part of synchronous call
+     * patterns (e.g. gen_server:call); let the woken receiver be
+     * eligible for inline scheduling handoff.
+     */
+    erts_sched_handoff_hint_begin();
     if (is_not_internal_pid(to)
         || !proc_queue_signal(sender, from, to, sig,
                               !(system || (is_pid(from) || is_port(from))),
                               ERTS_SIG_Q_OP_DEMONITOR)) {
         erts_monitor_release(mon);
     }
+    erts_sched_handoff_hint_end();
 }
 
 int
@@ -2963,6 +2970,7 @@ erts_proc_sig_send_monitor(ErtsPTabElementCommon *sender, Eterm from,
 {
     ErtsSignal *sig = (ErtsSignal *) mon;
     Uint32 type = ERTS_ML_GET_TYPE(mon);
+    int res;
 
     ASSERT(is_internal_pid(to) || to == am_undefined);
     ASSERT(erts_monitor_is_target(mon));
@@ -2970,7 +2978,11 @@ erts_proc_sig_send_monitor(ErtsPTabElementCommon *sender, Eterm from,
     sig->common.tag = ERTS_PROC_SIG_MAKE_TAG(ERTS_SIG_Q_OP_MONITOR,
                                              type, 0);
 
-    return proc_queue_signal(sender, from, to, sig, 0, ERTS_SIG_Q_OP_MONITOR);
+    /* See erts_proc_sig_send_demonitor() */
+    erts_sched_handoff_hint_begin();
+    res = proc_queue_signal(sender, from, to, sig, 0, ERTS_SIG_Q_OP_MONITOR);
+    erts_sched_handoff_hint_end();
+    return res;
 }
 
 void

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -132,6 +132,7 @@ const Process erts_invalid_process = {{ERTS_INVALID_PID}};
 int ERTS_WRITE_UNLIKELY(erts_default_spo_flags) = SPO_ON_HEAP_MSGQ;
 int ERTS_WRITE_UNLIKELY(erts_sched_compact_load);
 int ERTS_WRITE_UNLIKELY(erts_sched_balance_util) = 0;
+int ERTS_WRITE_UNLIKELY(erts_sched_inline_handoff) = 1;
 Uint ERTS_WRITE_UNLIKELY(erts_no_schedulers);
 Uint ERTS_WRITE_UNLIKELY(erts_no_total_schedulers);
 Uint ERTS_WRITE_UNLIKELY(erts_no_dirty_cpu_schedulers) = 0;
@@ -3970,6 +3971,35 @@ enqueue_process(ErtsRunQueue *runq, int prio, Process *p)
     enqueue_process_internal(rpq, p);
 }
 
+/*
+ * Mirror of enqueue_process() that prepends instead of appends, placing
+ * the process at the HEAD of its run queue (a queue jump). Used by
+ * inline scheduling handoff (+sih) so the woken process runs next, on
+ * the waker's donated reductions.
+ */
+static ERTS_INLINE void
+enqueue_process_head(ErtsRunQueue *runq, int prio, Process *p)
+{
+    ErtsRunPrioQueue *rpq;
+
+    ERTS_LC_ASSERT(erts_lc_runq_is_locked(runq));
+
+    erts_inc_runq_len(runq, &runq->procs.prio_info[prio], prio);
+
+    if (prio == PRIORITY_LOW) {
+        p->schedule_count = RESCHEDULE_LOW;
+        rpq = &runq->procs.prio[PRIORITY_NORMAL];
+    }
+    else {
+        p->schedule_count = 1;
+        rpq = &runq->procs.prio[prio];
+    }
+    p->next = rpq->first;
+    rpq->first = p;
+    if (!rpq->last)
+        rpq->last = p;
+}
+
 static ERTS_INLINE void
 unqueue_process_no_update_lengths(ErtsRunPrioQueue *rpq,
 		Process *prev_proc,
@@ -6048,6 +6078,13 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
     esdp->virtual_reds = 0;
     esdp->cpu_id = -1;
 
+    esdp->handoff.hint = 0;
+    esdp->handoff.pid = NIL;
+    esdp->handoff.reds = 0;
+    esdp->handoff.granted = CONTEXT_REDS;
+    esdp->handoff.count = 0;
+    esdp->handoff.picks = 0;
+
     erts_init_atom_cache_map(&esdp->atom_cache_map);
 
     esdp->last_monotonic_time = 0;
@@ -6864,34 +6901,108 @@ schedule_out_process(ErtsRunQueue *c_rq, erts_aint32_t *statep, Process *p,
     }
 }
 
+/*
+ * Smallest donated time slice worth an inline handoff; with less left
+ * than this the woken process is granted a full slice as usual.
+ */
+#define ERTS_SCHED_HANDOFF_MIN_REDS (CONTEXT_REDS / 20)
+
+/*
+ * Inline scheduling handoff (reduction sharing).
+ *
+ * When the currently executing process wakes another process up by
+ * sending it a message, the woken process is placed on the current
+ * scheduler's run queue without notifying any other scheduler, and
+ * the scheduler is armed to donate the remaining part of the sender's
+ * time slice to the woken process when it is picked for execution.
+ * This makes synchronous call patterns (send + blocking receive)
+ * behave more like a direct function call: no inter-scheduler wakeup,
+ * better cache locality, and a shared reduction budget that bounds
+ * inline call chains.
+ */
+static ERTS_INLINE ErtsRunQueue *
+maybe_handoff_runq(int enqueue, erts_aint32_t prio, Process *proc,
+                   ErtsRunQueue *runq, int *handoffp)
+{
+    ErtsSchedulerData *esdp;
+
+    if (!erts_sched_inline_handoff
+        || enqueue != ERTS_ENQUEUE_NORMAL_QUEUE
+        || prio != PRIORITY_NORMAL)
+        return runq;
+
+    esdp = erts_get_scheduler_data();
+    if (!esdp
+        || esdp->type != ERTS_SCHED_NORMAL
+        || !esdp->handoff.hint
+        || !esdp->current_process
+        || esdp->current_process == proc
+        || esdp->handoff.pid != NIL)
+        return runq;
+
+    if (runq != esdp->run_queue) {
+        if (!erts_try_change_runq_proc(proc, esdp->run_queue))
+            return runq; /* Bound to another run queue */
+        runq = esdp->run_queue;
+    }
+
+    esdp->handoff.pid = proc->common.id;
+    esdp->handoff.count++;
+    *handoffp = !0;
+    return runq;
+}
+
 static ERTS_INLINE void
 add2runq(int enqueue, erts_aint32_t prio,
 	 Process *proc, erts_aint32_t state)
 {
     ErtsRunQueue *runq;
+    int handoff = 0;
 
     runq = select_enqueue_run_queue(enqueue, prio, proc, state);
 
     if (runq) {
 	Process *sched_p = proc;
-        
+
 	if (enqueue < 0) { /* use proxy */
 	    Process *pxy;
 
 	    pxy = NULL;
 	    sched_p = make_proxy_proc(pxy, proc, prio);
 	}
+        else {
+            runq = maybe_handoff_runq(enqueue, prio, proc, runq, &handoff);
+        }
 
         if (ERTS_RUNQ_IX_IS_DIRTY(runq->ix))
             erts_proc_inc_refc(proc);
-        
+
 	erts_runq_lock(runq);
 
 	/* Enqueue the process */
-	enqueue_process(runq, (int) prio, sched_p);
+        if (handoff) {
+            /*
+             * Queue-jump to the head of the run queue: the woken
+             * process runs next, inline on the reductions donated by
+             * the waker, so it takes no more scheduler time than the
+             * waker was already entitled to. If the donation turns out
+             * to be exhausted it is demoted to the tail at the next
+             * pick (see erts_schedule()).
+             */
+            enqueue_process_head(runq, (int) prio, sched_p);
+        }
+        else {
+            enqueue_process(runq, (int) prio, sched_p);
+        }
 
 	erts_runq_unlock(runq);
-	smp_notify_inc_runq(runq);
+        /*
+         * No need to notify when handing off; the woken process will
+         * be picked up by this scheduler when the current process
+         * yields or suspends.
+         */
+        if (!handoff)
+            smp_notify_inc_runq(runq);
     }
 }
 
@@ -9679,6 +9790,20 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 
     internal_sched_out_proc:
 
+        if (is_normal_sched && esdp->handoff.pid != NIL) {
+            /*
+             * The process being scheduled out armed an inline handoff;
+             * record the unused part of its time slice so that it can
+             * be donated to the woken process at the next pick.
+             */
+            int hreds = esdp->handoff.granted - actual_reds;
+            if (hreds < 0)
+                hreds = 0;
+            else if (hreds > CONTEXT_REDS)
+                hreds = CONTEXT_REDS;
+            esdp->handoff.reds = hreds;
+        }
+
 	ERTS_CHK_HAVE_ONLY_MAIN_PROC_LOCK(p);
         ASSERT(p->scheduler_data || ERTS_SCHEDULER_IS_DIRTY(esdp));
 
@@ -9936,6 +10061,8 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	    }
 
 	    (void) ERTS_RUNQ_FLGS_UNSET(rq, ERTS_RUNQ_FLG_EXEC);
+            /* Disarm any stale inline handoff before going to sleep */
+            esdp->handoff.pid = NIL;
 	    scheduler_wait(&fcalls, esdp, rq);
 	    flags = ERTS_RUNQ_FLGS_SET_NOB(rq, ERTS_RUNQ_FLG_EXEC);
 	    flags |= ERTS_RUNQ_FLG_EXEC;
@@ -9994,6 +10121,27 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	    erts_aint32_t psflg_band_mask;
 	    int prio_q;
 	    int qmask, qbit;
+
+            if (is_normal_sched
+                && esdp->handoff.pid != NIL
+                && esdp->handoff.reds < ERTS_SCHED_HANDOFF_MIN_REDS) {
+                /*
+                 * The donated time slice is exhausted; demote the
+                 * queue-jumped process to the tail of the queue so
+                 * that it cannot starve other runnable processes.
+                 */
+                ErtsRunPrioQueue *rpq = &rq->procs.prio[PRIORITY_NORMAL];
+                Process *hop = rpq->first;
+                if (hop
+                    && hop->common.id == esdp->handoff.pid
+                    && hop != rpq->last) {
+                    rpq->first = hop->next;
+                    rpq->last->next = hop;
+                    rpq->last = hop;
+                    hop->next = NULL;
+                }
+                esdp->handoff.pid = NIL;
+            }
 
 	    flags = ERTS_RUNQ_FLGS_GET_NOB(rq);
 	    qmask = (int) (flags & ERTS_RUNQ_FLGS_PROCS_QMASK);
@@ -10181,6 +10329,26 @@ execute_process:
 
 	    calls = 0;
 	    reds = context_reds;
+
+            if (is_normal_sched
+                && erts_sched_inline_handoff != ERTS_SCHED_HANDOFF_OFF) {
+                if (esdp->handoff.pid != NIL) {
+                    if (esdp->handoff.pid == p->common.id) {
+                        esdp->handoff.picks++;
+                        if (esdp->handoff.reds >= ERTS_SCHED_HANDOFF_MIN_REDS) {
+                            /*
+                             * Run the woken process inline on the unused
+                             * part of the waker's time slice.
+                             */
+                            reds = esdp->handoff.reds;
+                        }
+                    }
+                    esdp->handoff.pid = NIL;
+                }
+                /* Record the budget granted, so that the unused part can
+                 * be donated if this process arms a handoff in turn. */
+                esdp->handoff.granted = reds;
+            }
 
 	    erts_runq_unlock(rq);
 

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -132,7 +132,7 @@ const Process erts_invalid_process = {{ERTS_INVALID_PID}};
 int ERTS_WRITE_UNLIKELY(erts_default_spo_flags) = SPO_ON_HEAP_MSGQ;
 int ERTS_WRITE_UNLIKELY(erts_sched_compact_load);
 int ERTS_WRITE_UNLIKELY(erts_sched_balance_util) = 0;
-int ERTS_WRITE_UNLIKELY(erts_sched_inline_handoff) = 1;
+int ERTS_WRITE_UNLIKELY(erts_sched_inline_handoff) = ERTS_SCHED_HANDOFF_INLINE;
 Uint ERTS_WRITE_UNLIKELY(erts_no_schedulers);
 Uint ERTS_WRITE_UNLIKELY(erts_no_total_schedulers);
 Uint ERTS_WRITE_UNLIKELY(erts_no_dirty_cpu_schedulers) = 0;
@@ -6925,8 +6925,9 @@ maybe_handoff_runq(int enqueue, erts_aint32_t prio, Process *proc,
                    ErtsRunQueue *runq, int *handoffp)
 {
     ErtsSchedulerData *esdp;
+    int mode = erts_sched_inline_handoff;
 
-    if (!erts_sched_inline_handoff
+    if (mode == ERTS_SCHED_HANDOFF_OFF
         || enqueue != ERTS_ENQUEUE_NORMAL_QUEUE
         || prio != PRIORITY_NORMAL)
         return runq;
@@ -6936,8 +6937,7 @@ maybe_handoff_runq(int enqueue, erts_aint32_t prio, Process *proc,
         || esdp->type != ERTS_SCHED_NORMAL
         || !esdp->handoff.hint
         || !esdp->current_process
-        || esdp->current_process == proc
-        || esdp->handoff.pid != NIL)
+        || esdp->current_process == proc)
         return runq;
 
     if (runq != esdp->run_queue) {
@@ -6946,9 +6946,14 @@ maybe_handoff_runq(int enqueue, erts_aint32_t prio, Process *proc,
         runq = esdp->run_queue;
     }
 
-    esdp->handoff.pid = proc->common.id;
     esdp->handoff.count++;
-    *handoffp = !0;
+    if (mode == ERTS_SCHED_HANDOFF_INLINE && esdp->handoff.pid == NIL) {
+        esdp->handoff.pid = proc->common.id;
+        *handoffp = ERTS_SCHED_HANDOFF_INLINE;
+    }
+    else {
+        *handoffp = ERTS_SCHED_HANDOFF_MIGRATE;
+    }
     return runq;
 }
 
@@ -6980,7 +6985,7 @@ add2runq(int enqueue, erts_aint32_t prio,
 	erts_runq_lock(runq);
 
 	/* Enqueue the process */
-        if (handoff) {
+        if (handoff == ERTS_SCHED_HANDOFF_INLINE) {
             /*
              * Queue-jump to the head of the run queue: the woken
              * process runs next, inline on the reductions donated by

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -106,6 +106,7 @@ struct saved_calls {
 extern Export exp_send, exp_receive, exp_timeout;
 extern int ERTS_WRITE_UNLIKELY(erts_sched_compact_load);
 extern int ERTS_WRITE_UNLIKELY(erts_sched_balance_util);
+extern int ERTS_WRITE_UNLIKELY(erts_sched_inline_handoff);
 extern Uint ERTS_WRITE_UNLIKELY(erts_no_schedulers);
 extern Uint ERTS_WRITE_UNLIKELY(erts_no_total_schedulers);
 extern Uint ERTS_WRITE_UNLIKELY(erts_no_dirty_cpu_schedulers);
@@ -706,6 +707,15 @@ struct ErtsSchedulerData_ {
     ErtsRunQueue *run_queue;
     int virtual_reds;
     int cpu_id;			/* >= 0 when bound */
+    struct {
+        int hint;       /* non-zero while executing a message-send wakeup
+                           performed by current_process */
+        Eterm pid;      /* pid of process armed for inline handoff */
+        int reds;       /* leftover reductions to donate at handoff pick */
+        int granted;    /* reductions granted to executing process at pick */
+        Uint64 count;   /* number of inline handoffs armed */
+        Uint64 picks;   /* number of armed processes picked inline */
+    } handoff;
     ErtsAuxWorkData aux_work_data;
     ErtsAtomCacheMap atom_cache_map;
 
@@ -2565,6 +2575,8 @@ ERTS_GLB_INLINE ErtsRunQueue *erts_bind_runq_proc(Process *p, int bind);
 ERTS_GLB_INLINE int erts_proc_runq_is_bound(Process *p);
 ERTS_GLB_INLINE ErtsRunQueue *erts_get_runq_proc(Process *p, int *boundp);
 ERTS_GLB_INLINE ErtsRunQueue *erts_get_runq_current(ErtsSchedulerData *esdp);
+ERTS_GLB_INLINE void erts_sched_handoff_hint_begin(void);
+ERTS_GLB_INLINE void erts_sched_handoff_hint_end(void);
 ERTS_GLB_INLINE void erts_runq_lock(ErtsRunQueue *rq);
 ERTS_GLB_INLINE int erts_runq_trylock(ErtsRunQueue *rq);
 ERTS_GLB_INLINE void erts_runq_unlock(ErtsRunQueue *rq);
@@ -2806,6 +2818,33 @@ erts_get_runq_current(ErtsSchedulerData *esdp)
     if (!esdp)
 	esdp = erts_get_scheduler_data();
     return esdp->run_queue;
+}
+
+/*
+ * Mark that wakeups performed until the corresponding end call are
+ * caused by a message sent by the currently executing process, making
+ * the woken process eligible for inline scheduling handoff. When inline
+ * handoff is disabled this is a single predictable branch with no
+ * scheduler lookup, keeping the message-send path free.
+ */
+ERTS_GLB_INLINE void
+erts_sched_handoff_hint_begin(void)
+{
+    if (erts_sched_inline_handoff != ERTS_SCHED_HANDOFF_OFF) {
+        ErtsSchedulerData *esdp = erts_get_scheduler_data();
+        if (esdp)
+            esdp->handoff.hint = 1;
+    }
+}
+
+ERTS_GLB_INLINE void
+erts_sched_handoff_hint_end(void)
+{
+    if (erts_sched_inline_handoff != ERTS_SCHED_HANDOFF_OFF) {
+        ErtsSchedulerData *esdp = erts_get_scheduler_data();
+        if (esdp)
+            esdp->handoff.hint = 0;
+    }
 }
 
 ERTS_GLB_INLINE void

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -106,6 +106,10 @@ struct saved_calls {
 extern Export exp_send, exp_receive, exp_timeout;
 extern int ERTS_WRITE_UNLIKELY(erts_sched_compact_load);
 extern int ERTS_WRITE_UNLIKELY(erts_sched_balance_util);
+/* Inline scheduling handoff modes (+sih) */
+#define ERTS_SCHED_HANDOFF_OFF     0  /* wake on assigned run queue */
+#define ERTS_SCHED_HANDOFF_MIGRATE 1  /* migrate to waker's run queue (tail) */
+#define ERTS_SCHED_HANDOFF_INLINE  2  /* migrate + queue jump + donated slice */
 extern int ERTS_WRITE_UNLIKELY(erts_sched_inline_handoff);
 extern Uint ERTS_WRITE_UNLIKELY(erts_no_schedulers);
 extern Uint ERTS_WRITE_UNLIKELY(erts_no_total_schedulers);

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -3476,8 +3476,17 @@ consume_timeslice_test(Config) when is_list(Config) ->
     {trace, P, exit, Done} = next_tmsg(P),
 
     ExpReds = (100 + 90 + 10 + 25*5 + 75) * CONTEXT_REDS div 100,
+    %% Reduction-count tolerance. It must also absorb the shift introduced
+    %% by scheduler inline handoff (+sih, on by default): P is woken by the
+    %% `P ! Go` message send above, so +sih may run P's first scheduling
+    %% quantum on a donated (shorter) time slice, which lowers the measured
+    %% reduction count by a small amount. CONTEXT_REDS div 100 (one
+    %% percentage point) covers that while staying far tighter than the
+    %% >= 1 percentage point shift a real consume_timeslice regression
+    %% would produce.
+    Tol = CONTEXT_REDS div 100,
     receive
-	{RedDiff, Reductions} when Reductions < (ExpReds + 10), Reductions > (ExpReds - 10) ->
+	{RedDiff, Reductions} when Reductions < (ExpReds + Tol), Reductions > (ExpReds - Tol) ->
 	    io:format("Reductions = ~p~n", [Reductions]),
 	    ok;
 	{RedDiff, Reductions} ->

--- a/erts/emulator/test/scheduler_SUITE.erl
+++ b/erts/emulator/test/scheduler_SUITE.erl
@@ -65,7 +65,10 @@
 	 reader_groups/1,
          otp_16446/1,
          simultaneously_change_schedulers_online/1,
-         simultaneously_change_schedulers_online_with_exits/1]).
+         simultaneously_change_schedulers_online_with_exits/1,
+         inline_handoff/1,
+         inline_handoff_gen_server/1,
+         inline_handoff_liveness/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -85,7 +88,10 @@ all() ->
      reader_groups,
      otp_16446,
      simultaneously_change_schedulers_online,
-     simultaneously_change_schedulers_online_with_exits].
+     simultaneously_change_schedulers_online_with_exits,
+     inline_handoff,
+     inline_handoff_gen_server,
+     inline_handoff_liveness].
 
 groups() -> 
     [{scheduler_bind, [],
@@ -2048,6 +2054,148 @@ simultaneously_change_schedulers_online_with_exits(Config) when is_list(Config) 
                   PMs),
     erlang:system_flag(schedulers_online, SchedOnline),
     ok.
+
+inline_handoff(Config) when is_list(Config) ->
+    %% The statistics counter must exist and be well-formed.
+    {Arms, Picks} = erlang:statistics(sched_inline_handoffs),
+    true = is_integer(Arms) andalso Arms >= 0,
+    true = is_integer(Picks) andalso Picks >= 0,
+
+    %% +sih false: inline handoff disabled; the counter must never move.
+    none = classify_handoff(inline_handoff_count("+sih false")),
+
+    %% +sih migrate: a woken process is migrated to the waker's run
+    %% queue and armed, but never picked inline (no reduction donation).
+    armed_only = classify_handoff(inline_handoff_count("+sih migrate")),
+
+    %% +sih true (and the default, no flag): a woken process is both
+    %% armed and picked inline on the waker's donated time slice.
+    armed_and_picked = classify_handoff(inline_handoff_count("+sih true")),
+    armed_and_picked = classify_handoff(inline_handoff_count("")),
+
+    ok.
+
+inline_handoff_gen_server(Config) when is_list(Config) ->
+    %% gen_server:call exercises two hint sites a plain message send does
+    %% not: the monitor set up before the request, and the alias/altact
+    %% reply. Under +sih it must both arm and pick inline; with the
+    %% feature off the counter must never move.
+    armed_and_picked =
+        classify_handoff(
+          inline_handoff_on_node("+sih true", fun inline_handoff_gs_calls/0)),
+    none =
+        classify_handoff(
+          inline_handoff_on_node("+sih false", fun inline_handoff_gs_calls/0)),
+    ok.
+
+inline_handoff_liveness(Config) when is_list(Config) ->
+    %% Many synchronous request/reply pairs on a single scheduler, which
+    %% maximises queue-jumping and the anti-starvation demotion. Every
+    %% reply must come back correct and in order -- catching a misrouted
+    %% wakeup or an armed-but-never-picked process (which would hang).
+    ok = inline_handoff_on_node("+sih true +S 1:1",
+                                fun () -> inline_handoff_pairs(50, 2000) end).
+
+%% Classify an {Arms, Picks} measurement (an unexpected combination,
+%% e.g. picks without arms, fails the function clause as it should).
+classify_handoff({0, 0}) -> none;
+classify_handoff({Arms, 0}) when Arms > 0 -> armed_only;
+classify_handoff({Arms, Picks}) when Arms > 0, Picks > 0 -> armed_and_picked.
+
+inline_handoff_count(Args) ->
+    inline_handoff_on_node(Args, fun () -> inline_handoff_pingpong(50000) end).
+
+%% Run Fun on a fresh peer node booted with the given +sih Args (ERL_FLAGS
+%% cleared so the parent's own flags do not leak in), returning Fun's result.
+inline_handoff_on_node(Args, Fun) ->
+    {ok, Peer, Node} = ?CT_PEER(#{args => string:lexemes(Args, " "),
+                                  env => [{"ERL_FLAGS", false}]}),
+    [Res] = mcall(Node, [Fun]),
+    peer:stop(Peer),
+    Res.
+
+%% Run a tight synchronous ping-pong (send + blocking receive on both
+%% sides), which is the canonical pattern that inline handoff targets,
+%% and return the {Arms, Picks} consumed by it.
+inline_handoff_pingpong(N) ->
+    Self = self(),
+    Resp = spawn_link(fun () -> inline_handoff_responder(Self) end),
+    {A0, P0} = erlang:statistics(sched_inline_handoffs),
+    inline_handoff_loop(Resp, N),
+    {A1, P1} = erlang:statistics(sched_inline_handoffs),
+    unlink(Resp),
+    exit(Resp, kill),
+    {A1 - A0, P1 - P0}.
+
+inline_handoff_responder(Driver) ->
+    receive
+        {Driver, M} ->
+            Driver ! {self(), M},
+            inline_handoff_responder(Driver)
+    end.
+
+inline_handoff_loop(_Resp, 0) ->
+    ok;
+inline_handoff_loop(Resp, N) ->
+    Resp ! {self(), N},
+    receive
+        {Resp, N} -> ok
+    end,
+    inline_handoff_loop(Resp, N - 1).
+
+%% Drive N gen_server:calls against a minimal "fake" gen_server -- a plain
+%% process that answers '$gen_call' via gen_server:reply/2 -- and return
+%% the {Arms, Picks} consumed. This is enough to exercise the monitor and
+%% alias-reply hint sites without a callback module.
+inline_handoff_gs_calls() ->
+    Server = spawn_link(fun inline_handoff_fake_server/0),
+    {A0, P0} = erlang:statistics(sched_inline_handoffs),
+    _ = [pong = gen_server:call(Server, ping) || _ <- lists:seq(1, 50000)],
+    {A1, P1} = erlang:statistics(sched_inline_handoffs),
+    unlink(Server),
+    exit(Server, kill),
+    {A1 - A0, P1 - P0}.
+
+inline_handoff_fake_server() ->
+    receive
+        {'$gen_call', From, ping} ->
+            gen_server:reply(From, pong),
+            inline_handoff_fake_server()
+    end.
+
+%% Spawn Pairs independent driver/responder pairs, each doing Iters
+%% synchronous round-trips with unique tags; returns ok only if every
+%% pair verifies all of its replies and finishes.
+inline_handoff_pairs(Pairs, Iters) ->
+    Parent = self(),
+    Drivers = [spawn_link(fun () -> inline_handoff_pair(Parent, K, Iters) end)
+               || K <- lists:seq(1, Pairs)],
+    inline_handoff_await(Drivers).
+
+inline_handoff_pair(Parent, K, Iters) ->
+    Self = self(),
+    Resp = spawn_link(fun () -> inline_handoff_responder(Self) end),
+    ok = inline_handoff_verify_loop(Resp, K, Iters),
+    unlink(Resp),
+    exit(Resp, kill),
+    Parent ! {done, Self}.
+
+inline_handoff_verify_loop(_Resp, _K, 0) ->
+    ok;
+inline_handoff_verify_loop(Resp, K, N) ->
+    Msg = {K, N},
+    Resp ! {self(), Msg},
+    receive
+        {Resp, Msg} -> inline_handoff_verify_loop(Resp, K, N - 1)
+    after 60000 -> error({inline_handoff_timeout, K, N})
+    end.
+
+inline_handoff_await([]) ->
+    ok;
+inline_handoff_await(Drivers) ->
+    receive
+        {done, Pid} -> inline_handoff_await(Drivers -- [Pid])
+    end.
 
 
 %%

--- a/erts/emulator/test/trace_port_SUITE.erl
+++ b/erts/emulator/test/trace_port_SUITE.erl
@@ -271,6 +271,13 @@ process_events(Config) when is_list(Config) ->
 schedule(Config) when is_list(Config) ->
     start_tracer(Config),
     Receiver = fun_spawn(fun receiver/0),
+    %% Make sure the receiver has reached its receive and suspended
+    %% before enabling 'running' trace. Otherwise the first scheduling
+    %% event observed may be for the initial erlang:apply/2 frame rather
+    %% than for receiver/0, depending on scheduling interleaving (for
+    %% example, the receiver may not be run in parallel before the first
+    %% trace event when scheduler inline handoff is enabled).
+    wait_until_suspended(Receiver),
     trac(Receiver, true, [running]),
 
     Receiver ! hi,
@@ -521,6 +528,17 @@ tracer_loop(RelayTo, Port) ->
             tracer_loop(RelayTo, Port);
         Other ->
             exit({bad_message,Other})
+    end.
+
+%% Wait until Pid is suspended in a receive (status 'waiting'), i.e. has
+%% executed past its initial apply frame into its message loop.
+wait_until_suspended(Pid) ->
+    case process_info(Pid, status) of
+        {status, waiting} ->
+            ok;
+        _ ->
+            receive after 1 -> ok end,
+            wait_until_suspended(Pid)
     end.
 
 fun_spawn(Fun) ->

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -135,6 +135,7 @@ static char *pluss_val_switches[] = {
     "ct",
     "ecio",
     "fwi",
+    "ih",
     "tbt",
     "wct",
     "wtdcpu",


### PR DESCRIPTION
This pull request introduces a new "scheduler inline handoff" feature to the Erlang runtime, controlled by the `+sih` flag. This feature allows processes that wake other processes (e.g., via message send) to "hand off" their remaining scheduler time slice, improving latency and cache locality for synchronous communication patterns. The implementation includes a new scheduler mode, runtime statistics, command-line flag parsing, and changes to the process scheduling logic.

**Scheduler Inline Handoff Feature:**

* Added the `+sih true|migrate|false` runtime flag to control scheduler inline handoff behavior, with documentation and command-line parsing support. [[1]](diffhunk://#diff-de4351ba133340c79fdc4114d3baea266b0d2a109fa619db0ab03c03f455a71dR1259-R1275) [[2]](diffhunk://#diff-3517781afd08bfe826dcc3babdfa35cdabb9d13011d5dd9ae49922f3996cadb5R677-R679) [[3]](diffhunk://#diff-3517781afd08bfe826dcc3babdfa35cdabb9d13011d5dd9ae49922f3996cadb5R2046-R2060)
* Implemented three modes: `true` (inline handoff with queue jump and donated slice), `migrate` (move to waker's run queue without inline execution), and `false` (default scheduling). [[1]](diffhunk://#diff-551473771c85cdc832d407987b7e8f8fc5e8cf1fd0caf6fd6f6b2752e8d9d843R109-R113) [[2]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R6904-R6965)

**Process Scheduling and Handoff Logic:**

* Modified the process scheduling logic to support inline handoff, including queue-jumping the woken process, donating remaining reductions, and demoting the process if the donation is exhausted. [[1]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R3974-R4002) [[2]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R6904-R6965) [[3]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R6978-R7009) [[4]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R9798-R9811) [[5]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R10130-R10150) [[6]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R10338-R10357)
* Added handoff tracking fields to `ErtsSchedulerData` and initialized them appropriately. [[1]](diffhunk://#diff-551473771c85cdc832d407987b7e8f8fc5e8cf1fd0caf6fd6f6b2752e8d9d843R714-R722) [[2]](diffhunk://#diff-9a4db3c82d3b222510341bd349ad20968b534679caeb5506409ce1e2a4a1c840R6081-R6087)

**Message Send Path Integration:**

* Marked message sends and related actions (including alternate actions and monitor/demonitor signals) as eligible for inline handoff using new hint functions. [[1]](diffhunk://#diff-44d87477159acd8ed8d3dc81974c684e9c38212ebc134f303859d7f9e39b091fR456-R465) [[2]](diffhunk://#diff-5aa7986c6f146e2ab8a0445fb7d55a6770169f5a8723373a772291ba69944717R2274-R2285) [[3]](diffhunk://#diff-5aa7986c6f146e2ab8a0445fb7d55a6770169f5a8723373a772291ba69944717R2952-R2964) [[4]](diffhunk://#diff-5aa7986c6f146e2ab8a0445fb7d55a6770169f5a8723373a772291ba69944717R2973-R2985)
* Introduced `erts_sched_handoff_hint_begin` and `erts_sched_handoff_hint_end` to bracket wakeup operations, minimizing performance impact when the feature is disabled. [[1]](diffhunk://#diff-551473771c85cdc832d407987b7e8f8fc5e8cf1fd0caf6fd6f6b2752e8d9d843R2582-R2583) [[2]](diffhunk://#diff-551473771c85cdc832d407987b7e8f8fc5e8cf1fd0caf6fd6f6b2752e8d9d843R2827-R2853)

**Runtime Statistics and Observability:**

* Added a new atom (`sched_inline_handoffs`) and statistics reporting for the number of inline handoffs armed and picked, accessible via the `statistics(sched_inline_handoffs)` BIF. [[1]](diffhunk://#diff-d2730ae7b9a0a86c5e33c7a0b24f90bbe6fb762ff664760fdee6cb9eb1114597R654) [[2]](diffhunk://#diff-fd06bd036841ae951150b5cab12e6ffce70198cf6a00084b7d5991b60cf04e7eR4231-R4246)

These changes collectively improve the efficiency of synchronous communication patterns in the Erlang VM by reducing scheduler contention and improving cache locality, while providing runtime control and observability of the new behavior.