### PR TITLE
Handle table exhaustion gracefully to prevent node crashes

### DIFF
--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -328,7 +328,10 @@ erts_atom_put_index(const byte *name, Sint len, ErtsAtomEncoding enc, int trunc)
     a.latin1_chars = (Sint16) no_latin1_chars;
     a.u.name = (byte *) text;
     atom_write_lock();
-    aix = index_put(&erts_atom_table, (void*) &a);
+    {
+        IndexSlot *slot = index_put_entry_may_fail(&erts_atom_table, (void*) &a);
+        aix = slot ? slot->index : ATOM_MAX_LIMIT_ERROR;
+    }
     atom_write_unlock();
     return aix;
 }
@@ -344,6 +347,27 @@ erts_atom_put(const byte *name, Sint len, ErtsAtomEncoding enc, int trunc)
 	return make_atom(aix);
     else
 	return THE_NON_VALUE;
+}
+
+/*
+ * Like erts_atom_put() but aborts the node if the atom cannot be created.
+ * Intended for the handful of internal call sites that have no way to
+ * propagate a failure (public driver APIs, the match-spec compiler, etc.)
+ * and would otherwise store THE_NON_VALUE into a live term should the atom
+ * table be full. This restores the pre-catchable-system_limit behaviour
+ * (a full atom table used to abort unconditionally inside index_put_entry())
+ * for exactly those paths, without reintroducing a node-kill on the
+ * user-reachable BIFs, which handle the THE_NON_VALUE return themselves.
+ */
+Eterm
+erts_atom_put_or_die(const byte *name, Sint len, ErtsAtomEncoding enc, int trunc)
+{
+    Eterm res = erts_atom_put(name, len, enc, trunc);
+    if (is_non_value(res)) {
+	/* A core dump is unnecessary */
+	erts_exit(ERTS_DUMP_EXIT, "no more atoms (atom table full)\n");
+    }
+    return res;
 }
 
 Eterm

--- a/erts/emulator/beam/atom.h
+++ b/erts/emulator/beam/atom.h
@@ -33,6 +33,7 @@
 #define MIN_ATOM_TABLE_SIZE 8192
 #define ATOM_BAD_ENCODING_ERROR -1
 #define ATOM_MAX_CHARS_ERROR -2
+#define ATOM_MAX_LIMIT_ERROR -3 /* atom table full (catchable system_limit) */
 
 #ifndef ARCH_32
 /* Internal atom cache needs MAX_ATOM_TABLE_SIZE to be less than an
@@ -158,6 +159,9 @@ int atom_table_sz(void);	/* table size in bytes, excluding stored objects */
 
 Eterm am_atom_put(const char*, Sint); /* ONLY 7-bit ascii! */
 Eterm erts_atom_put(const byte *name, Sint len, ErtsAtomEncoding enc, int trunc);
+/* Like erts_atom_put() but aborts the node on failure; for internal call
+   sites that cannot propagate a full-atom-table error (see atom.c). */
+Eterm erts_atom_put_or_die(const byte *name, Sint len, ErtsAtomEncoding enc, int trunc);
 int erts_atom_put_index(const byte *name, Sint len, ErtsAtomEncoding enc, int trunc);
 void init_atom_table(void);
 void atom_info(fmtfn_t, void *);

--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -1517,7 +1517,12 @@ apply(Process* p, Eterm* reg, ErtsCodePtr I, Uint stack_offset)
 
     /* Call the referenced function, if any: should the function not be found,
      * create a stub entry which in turn calls the error handler. */
-    ep = erts_export_get_or_make_stub(module, function, arity);
+    ep = erts_export_get_or_make_stub_or_null(module, function, arity);
+    if (ep == NULL) {
+        /* Export table full -> catchable system_limit, not a node abort. */
+        p->freason = SYSTEM_LIMIT;
+        goto error2;
+    }
 
     apply_bif_error_adjustment(p, ep, reg, arity, I, stack_offset);
     DTRACE_GLOBAL_CALL_FROM_EXPORT(p, ep);
@@ -1558,7 +1563,12 @@ fixed_apply(Process* p, Eterm* reg, Uint arity,
 
     /* Call the referenced function, if any: should the function not be found,
      * create a stub entry which in turn calls the error handler. */
-    ep = erts_export_get_or_make_stub(module, function, arity);
+    ep = erts_export_get_or_make_stub_or_null(module, function, arity);
+    if (ep == NULL) {
+        /* Export table full -> catchable system_limit, not a node abort. */
+        p->freason = SYSTEM_LIMIT;
+        return NULL;
+    }
 
     apply_bif_error_adjustment(p, ep, reg, arity, I, stack_offset);
     DTRACE_GLOBAL_CALL_FROM_EXPORT(p, ep);

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -224,6 +224,29 @@ erts_prepare_loading(Binary* magic, Process *c_p, Eterm group_leader,
                        "Erlang/OTP 25 or later.\n");
     }
 
+    /*
+     * Refuse the load up front with a catchable system_limit if the module,
+     * export or fun table cannot hold this module's entries, rather than
+     * aborting the node from index_put_entry() while committing the code.
+     *
+     * The export estimate (own exports + imports) is a conservative upper
+     * bound: imports that resolve to already-present entries consume no slot,
+     * so a load may be refused slightly before the true limit. The check uses
+     * the staging table (the one a load inserts into); a concurrent atomic
+     * multi-module load could in principle still overflow between here and the
+     * commit, in which case the old abort behaviour remains as a backstop.
+     */
+    if (!erts_module_table_would_fit(1)
+        || !erts_export_table_would_fit(stp->beam.exports.count
+                                        + stp->beam.imports.count)
+        || !erts_fun_table_would_fit(stp->beam.lambdas.count)) {
+        retval = am_system_limit;
+        beam_load_report_error(__LINE__, stp,
+                               "no room to load module: the module, export "
+                               "or fun table is full");
+        goto load_error;
+    }
+
     if (!load_code(stp)) {
         goto load_error;
     }

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -4481,7 +4481,11 @@ BIF_RETTYPE make_fun_3(BIF_ALIST_3)
         BIF_ERROR(BIF_P, BADARG);
     }
 
-    ep = erts_export_get_or_make_stub(BIF_ARG_1, BIF_ARG_2, (Uint) arity);
+    ep = erts_export_get_or_make_stub_or_null(BIF_ARG_1, BIF_ARG_2, (Uint) arity);
+    if (ep == NULL) {
+        /* Export table full -> catchable system_limit, not a node abort. */
+        BIF_ERROR(BIF_P, SYSTEM_LIMIT);
+    }
     BIF_RET(ep->lambda);
 }
 

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -3223,8 +3223,12 @@ BIF_RETTYPE list_to_atom_1(BIF_ALIST_1)
 	BIF_ERROR(BIF_P, BADARG);
     }
     res = erts_atom_put(buf, written, ERTS_ATOM_ENC_UTF8, 1);
-    ASSERT(is_atom(res));
     erts_free(ERTS_ALC_T_TMP, (void *) buf);
+    if (is_non_value(res)) {
+        /* The name is already validated above, so the only way to get here
+           is a full atom table. */
+        BIF_ERROR(BIF_P, SYSTEM_LIMIT);
+    }
     BIF_RET(res);
 }
 

--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -82,7 +82,7 @@ BIF_RETTYPE erts_internal_open_port_2(BIF_ALIST_2)
                 BIF_ERROR(BIF_P, EXC_INTERNAL_ERROR);
 	} else if (err_type == -2) {
 	    str = erl_errno_id(err_num);
-            res = erts_atom_put((byte *) str, sys_strlen(str), ERTS_ATOM_ENC_LATIN1, 1);
+            res = erts_atom_put_or_die((byte *) str, sys_strlen(str), ERTS_ATOM_ENC_LATIN1, 1);
 	} else {
 	    res = am_einval;
 	}

--- a/erts/emulator/beam/erl_code_staged.h
+++ b/erts/emulator/beam/erl_code_staged.h
@@ -202,12 +202,14 @@ ERTS_CODE_STAGED_FUNC__(init_template)(ERTS_CODE_STAGED_TEMPLATE_T__ *template)
 }
 
 static ERTS_CODE_STAGED_OBJECT_TYPE *
-ERTS_CODE_STAGED_FUNC__(upsert)(ERTS_CODE_STAGED_TEMPLATE_T__ *template)
+ERTS_CODE_STAGED_FUNC__(upsert)(ERTS_CODE_STAGED_TEMPLATE_T__ *template,
+                                int may_fail)
 {
     IndexTable * const tables = ERTS_CODE_STAGED_CONCAT_MACRO_VALUES__
                                  (ERTS_CODE_STAGED_PREFIX, _tables);
     ERTS_CODE_STAGED_ENTRY_T__ *entry;
     int requires_insertion = 0;
+    int table_full = 0;
 #ifdef DEBUG
     int retry_after_race = 0;
 #endif
@@ -246,6 +248,16 @@ ERTS_CODE_STAGED_FUNC__(upsert)(ERTS_CODE_STAGED_TEMPLATE_T__ *template)
                 /* If the staging table did not contain the entry, try to
                  * insert it under a write lock on the next pass. */
                 requires_insertion = (entry == NULL);
+            } else if (may_fail) {
+                /* Return NULL instead of aborting the node when the table
+                 * is full, so the caller can raise a catchable error. */
+                entry = (ERTS_CODE_STAGED_ENTRY_T__*)
+                    index_put_entry_may_fail(&tables[staging_ix],
+                                             &template->entry);
+                if (entry == NULL) {
+                    table_full = 1;
+                }
+                ERTS_CODE_STAGED_FUNC__(write_unlock)();
             } else {
                 entry = (ERTS_CODE_STAGED_ENTRY_T__*)
                     index_put_entry(&tables[staging_ix],
@@ -266,9 +278,9 @@ ERTS_CODE_STAGED_FUNC__(upsert)(ERTS_CODE_STAGED_TEMPLATE_T__ *template)
                 ERTS_CODE_STAGED_FUNC__(write_unlock)();
             }
         }
-    } while (entry == NULL);
+    } while (entry == NULL && !table_full);
 
-    return entry->object;
+    return entry == NULL ? NULL : entry->object;
 }
 
 static ERTS_CODE_STAGED_ENTRY_T__ *

--- a/erts/emulator/beam/erl_code_staged.h
+++ b/erts/emulator/beam/erl_code_staged.h
@@ -564,6 +564,16 @@ ERTS_CODE_STAGED_FUNC__(list_size)(ErtsCodeIndex code_ix)
 }
 #endif
 
+#ifdef ERTS_CODE_STAGED_WANT_WOULD_FIT
+static int
+ERTS_CODE_STAGED_FUNC__(would_fit)(ErtsCodeIndex code_ix, int need)
+{
+    IndexTable * const tables = ERTS_CODE_STAGED_CONCAT_MACRO_VALUES__
+                                (ERTS_CODE_STAGED_PREFIX, _tables);
+    return erts_index_table_would_fit(&tables[code_ix], need);
+}
+#endif
+
 #ifdef ERTS_CODE_STAGED_WANT_TABLE_SIZE
 static int
 ERTS_CODE_STAGED_FUNC__(table_size)(void)

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -5821,8 +5821,10 @@ static int match_compact(ErlHeapFragment *expr, DMCErrInfo *err_info)
 		;
 	    ASSERT(j < x);
 	    erts_snprintf(buff+1, sizeof(buff) - 1, "%u", (unsigned) j);
-	    /* Yes, writing directly into terms, they ARE off heap */
-	    *p = erts_atom_put((byte *) buff, sys_strlen(buff),
+	    /* Yes, writing directly into terms, they ARE off heap.
+	       Abort rather than store THE_NON_VALUE here if the atom table
+	       is full -- there is no way to fail a compiled match program. */
+	    *p = erts_atom_put_or_die((byte *) buff, sys_strlen(buff),
 			       ERTS_ATOM_ENC_LATIN1, 1);
 	}
 	++p;

--- a/erts/emulator/beam/erl_fun.c
+++ b/erts/emulator/beam/erl_fun.c
@@ -293,7 +293,7 @@ ErlFunEntry *erts_fun_entry_put(Eterm mod,
 {
     fun_template_t template;
     init_fun_template(&template, mod, old_uniq, old_index, uniq, index, arity);
-    return fun_staged_upsert(&template);
+    return fun_staged_upsert(&template, 0);
 }
 
 const ErlFunEntry *erts_fun_entry_get_or_make_stub(Eterm mod,
@@ -305,7 +305,7 @@ const ErlFunEntry *erts_fun_entry_get_or_make_stub(Eterm mod,
 {
     fun_template_t template;
     init_fun_template(&template, mod, old_uniq, old_index, uniq, index, arity);
-    return fun_staged_upsert(&template);
+    return fun_staged_upsert(&template, 0);
 }
 
 void erts_fun_start_staging(void)

--- a/erts/emulator/beam/erl_fun.c
+++ b/erts/emulator/beam/erl_fun.c
@@ -127,6 +127,7 @@ static void fun_stage(ErlFunEntry *entry,
 #define ERTS_CODE_STAGED_WANT_FOREACH_ACTIVE
 #define ERTS_CODE_STAGED_WANT_ENTRY_BYTES
 #define ERTS_CODE_STAGED_WANT_TABLE_SIZE
+#define ERTS_CODE_STAGED_WANT_WOULD_FIT
 #define ERTS_CODE_STAGED_WANT_INFO
 
 #include "erl_code_staged.h"
@@ -144,6 +145,13 @@ void erts_fun_info(fmtfn_t to, void *to_arg)
 int erts_fun_table_sz(void)
 {
     return fun_staged_table_size();
+}
+
+/* Staging-table (the table a load inserts into) capacity check for the
+ * loader pre-flight; see beam_load.c. */
+int erts_fun_table_would_fit(int need)
+{
+    return fun_staged_would_fit(erts_staging_code_ix(), need);
 }
 
 int erts_fun_entries_sz(void)

--- a/erts/emulator/beam/erl_fun.h
+++ b/erts/emulator/beam/erl_fun.h
@@ -102,6 +102,7 @@ void erts_init_fun_table(void);
 void erts_fun_info(fmtfn_t, void *);
 int erts_fun_table_sz(void);
 int erts_fun_entries_sz(void);
+int erts_fun_table_would_fit(int need);
 
 /* Finds or inserts a fun entry that matches the given signature. */
 ErlFunEntry *erts_fun_entry_put(Eterm mod, int old_uniq, int old_index,

--- a/erts/emulator/beam/erl_record.c
+++ b/erts/emulator/beam/erl_record.c
@@ -174,7 +174,7 @@ erts_record_put(Eterm module, Eterm name) {
     record_template_t template;
 
     init_record_template(&template, module, name);
-    return record_staged_upsert(&template);
+    return record_staged_upsert(&template, 0);
 }
 
 struct record_module_delete_args {

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -1981,7 +1981,8 @@ binary_to_atom(Process* proc, Eterm bin, Eterm enc, int must_exist)
 	    badarg:
 		erts_free_aligned_binary_bytes(temp_alloc);
 		BIF_ERROR(proc, BADARG);
-	    } else if (lix == ATOM_MAX_CHARS_ERROR) {
+	    } else if (lix == ATOM_MAX_CHARS_ERROR
+		       || lix == ATOM_MAX_LIMIT_ERROR) {
 	    system_limit:
 		erts_free_aligned_binary_bytes(temp_alloc);
 		BIF_ERROR(proc, SYSTEM_LIMIT);
@@ -2000,7 +2001,8 @@ binary_to_atom(Process* proc, Eterm bin, Eterm enc, int must_exist)
 					  0);
 	    if (uix == ATOM_BAD_ENCODING_ERROR) {
 		goto badarg;
-	    } else if (uix == ATOM_MAX_CHARS_ERROR) {
+	    } else if (uix == ATOM_MAX_CHARS_ERROR
+		       || uix == ATOM_MAX_LIMIT_ERROR) {
 		goto system_limit;
 	    }
 

--- a/erts/emulator/beam/export.c
+++ b/erts/emulator/beam/export.c
@@ -238,7 +238,32 @@ Export *erts_export_get_or_make_stub(Eterm mod, Eterm func, unsigned int arity)
     object->info.mfa.function = func;
     object->info.mfa.arity = arity;
 
-    return export_staged_upsert(&template);
+    return export_staged_upsert(&template, 0);
+}
+
+/*
+ * Like erts_export_get_or_make_stub() but returns NULL instead of aborting
+ * the node when the export table is full. Used by paths that decode
+ * untrusted input (e.g. an external fun in binary_to_term/distribution),
+ * where a full export table must raise a catchable error rather than kill
+ * the node.
+ */
+
+Export *erts_export_get_or_make_stub_or_null(Eterm mod, Eterm func,
+                                             unsigned int arity)
+{
+    export_template_t template;
+    Export *object;
+
+    ASSERT(is_atom(mod));
+    ASSERT(is_atom(func));
+
+    object = export_staged_init_template(&template);
+    object->info.mfa.module = mod;
+    object->info.mfa.function = func;
+    object->info.mfa.arity = arity;
+
+    return export_staged_upsert(&template, 1);
 }
 
 Export *export_list(int i, ErtsCodeIndex code_ix)

--- a/erts/emulator/beam/export.c
+++ b/erts/emulator/beam/export.c
@@ -121,6 +121,7 @@ static void export_stage(Export *export,
 #define ERTS_CODE_STAGED_WANT_PUT
 #define ERTS_CODE_STAGED_WANT_LIST
 #define ERTS_CODE_STAGED_WANT_LIST_SIZE
+#define ERTS_CODE_STAGED_WANT_WOULD_FIT
 #define ERTS_CODE_STAGED_WANT_ENTRY_BYTES
 #define ERTS_CODE_STAGED_WANT_TABLE_SIZE
 #define ERTS_CODE_STAGED_WANT_INFO
@@ -225,7 +226,8 @@ Export *erts_export_put(Eterm mod, Eterm func, unsigned int arity)
  * Stub export entries will be placed in the staging export table.
  */
 
-Export *erts_export_get_or_make_stub(Eterm mod, Eterm func, unsigned int arity)
+static Export *get_or_make_stub(Eterm mod, Eterm func, unsigned int arity,
+                                int may_fail)
 {
     export_template_t template;
     Export *object;
@@ -238,7 +240,12 @@ Export *erts_export_get_or_make_stub(Eterm mod, Eterm func, unsigned int arity)
     object->info.mfa.function = func;
     object->info.mfa.arity = arity;
 
-    return export_staged_upsert(&template, 0);
+    return export_staged_upsert(&template, may_fail);
+}
+
+Export *erts_export_get_or_make_stub(Eterm mod, Eterm func, unsigned int arity)
+{
+    return get_or_make_stub(mod, func, arity, 0);
 }
 
 /*
@@ -248,22 +255,10 @@ Export *erts_export_get_or_make_stub(Eterm mod, Eterm func, unsigned int arity)
  * where a full export table must raise a catchable error rather than kill
  * the node.
  */
-
 Export *erts_export_get_or_make_stub_or_null(Eterm mod, Eterm func,
                                              unsigned int arity)
 {
-    export_template_t template;
-    Export *object;
-
-    ASSERT(is_atom(mod));
-    ASSERT(is_atom(func));
-
-    object = export_staged_init_template(&template);
-    object->info.mfa.module = mod;
-    object->info.mfa.function = func;
-    object->info.mfa.arity = arity;
-
-    return export_staged_upsert(&template, 1);
+    return get_or_make_stub(mod, func, arity, 1);
 }
 
 Export *export_list(int i, ErtsCodeIndex code_ix)
@@ -274,6 +269,13 @@ Export *export_list(int i, ErtsCodeIndex code_ix)
 int export_list_size(ErtsCodeIndex code_ix)
 {
     return export_staged_list_size(code_ix);
+}
+
+/* Staging-table (the table a load inserts into) capacity check for the
+ * loader pre-flight; see beam_load.c. */
+int erts_export_table_would_fit(int need)
+{
+    return export_staged_would_fit(erts_staging_code_ix(), need);
 }
 
 int export_table_sz(void)

--- a/erts/emulator/beam/export.h
+++ b/erts/emulator/beam/export.h
@@ -140,6 +140,7 @@ Export* erts_export_get_or_make_stub_or_null(Eterm, Eterm, unsigned);
 
 Export *export_list(int,ErtsCodeIndex);
 int export_list_size(ErtsCodeIndex);
+int erts_export_table_would_fit(int need);
 int export_table_sz(void);
 int export_entries_sz(void);
 const Export *export_get(const Export*);

--- a/erts/emulator/beam/export.h
+++ b/erts/emulator/beam/export.h
@@ -134,6 +134,9 @@ ERTS_GLB_INLINE const Export *erts_active_export_entry(Eterm m,
 Export* erts_export_put(Eterm mod, Eterm func, unsigned int arity);
 
 Export* erts_export_get_or_make_stub(Eterm, Eterm, unsigned);
+/* Like erts_export_get_or_make_stub() but returns NULL instead of aborting
+   the node when the export table is full (for untrusted decode paths). */
+Export* erts_export_get_or_make_stub_or_null(Eterm, Eterm, unsigned);
 
 Export *export_list(int,ErtsCodeIndex);
 int export_list_size(ErtsCodeIndex);

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -5020,7 +5020,12 @@ dec_term_atom_common:
                     }
                 }
 
-                export = erts_export_get_or_make_stub(mod, name, arity);
+                export = erts_export_get_or_make_stub_or_null(mod, name, arity);
+                if (export == NULL) {
+                    /* Export table full: fail the decode rather than abort
+                       the node (untrusted input). */
+                    goto error;
+                }
                 *objp = export->lambda;
             }
             break;

--- a/erts/emulator/beam/index.c
+++ b/erts/emulator/beam/index.c
@@ -129,6 +129,11 @@ index_put_entry(IndexTable* t, void* tmpl)
     return p;
 }
 
+int erts_index_table_would_fit(IndexTable* t, int need)
+{
+    return erts_index_num_entries(t) + need <= t->limit;
+}
+
 int index_get(IndexTable* t, void* tmpl)
 {
     IndexSlot* p = (IndexSlot*) hash_get(&t->htable, tmpl);

--- a/erts/emulator/beam/index.c
+++ b/erts/emulator/beam/index.c
@@ -72,24 +72,35 @@ erts_index_init(ErtsAlcType_t type, IndexTable* t, char* name,
 }
 
 IndexSlot*
-index_put_entry(IndexTable* t, void* tmpl)
+index_put_entry_may_fail(IndexTable* t, void* tmpl)
 {
-    int ix;
-    IndexSlot* p = (IndexSlot*) hash_put(&t->htable, tmpl);
+    int ix = t->entries;
+    IndexSlot* p;
 
+    /*
+     * Accepting a *new* entry here would require growing past the limit, so
+     * the table is full. Refuse without inserting anything, returning NULL so
+     * the caller can raise a catchable error instead of aborting the node
+     * (see index_put_entry()). An entry that is already present must still
+     * resolve even when full, so probe with hash_get (which never inserts)
+     * rather than hash_put -- this avoids a tentative insertion we would have
+     * to undo, and undoing is not free: the alloc callback may have
+     * side effects (e.g. atom_alloc() registers a global literal).
+     *
+     * The (ix >= size && ix >= limit) condition is exactly the point at which
+     * index_put_entry() used to abort, so behaviour is unchanged otherwise.
+     */
+    if (ix >= t->size && ix >= t->limit) {
+	return (IndexSlot*) hash_get(&t->htable, tmpl);
+    }
+
+    p = (IndexSlot*) hash_put(&t->htable, tmpl);
     if (p->index >= 0) {
 	return p;
     }
 
-    ix = t->entries;
     if (ix >= t->size) {
-	Uint sz;
-	if (ix >= t->limit) {
-	    /* A core dump is unnecessary */
-	    erts_exit(ERTS_DUMP_EXIT, "no more index entries in %s (max=%d)\n",
-		     t->htable.name, t->limit);
-	}
-	sz = INDEX_PAGE_SIZE*sizeof(IndexSlot*);
+	Uint sz = INDEX_PAGE_SIZE*sizeof(IndexSlot*);
 	t->seg_table[ix>>INDEX_PAGE_SHIFT] = erts_alloc(t->type, sz);
 	t->size += INDEX_PAGE_SIZE;
     }
@@ -103,6 +114,18 @@ index_put_entry(IndexTable* t, void* tmpl)
     ERTS_THR_WRITE_MEMORY_BARRIER;
     t->entries++;
 
+    return p;
+}
+
+IndexSlot*
+index_put_entry(IndexTable* t, void* tmpl)
+{
+    IndexSlot* p = index_put_entry_may_fail(t, tmpl);
+    if (p == NULL) {
+	/* A core dump is unnecessary */
+	erts_exit(ERTS_DUMP_EXIT, "no more index entries in %s (max=%d)\n",
+		 t->htable.name, t->limit);
+    }
     return p;
 }
 

--- a/erts/emulator/beam/index.h
+++ b/erts/emulator/beam/index.h
@@ -63,6 +63,9 @@ IndexSlot* index_put_entry(IndexTable*, void*);
    the table is full, so the caller can raise a catchable error. */
 IndexSlot* index_put_entry_may_fail(IndexTable*, void*);
 
+/* Returns non-zero if 'need' more entries would fit under the table limit. */
+int erts_index_table_would_fit(IndexTable*, int need);
+
 /* Erase all entries with index 'ix' and higher
 */
 void index_erase_latest_from(IndexTable*, Uint ix);

--- a/erts/emulator/beam/index.h
+++ b/erts/emulator/beam/index.h
@@ -59,6 +59,9 @@ int index_table_sz(IndexTable *);
 int index_get(IndexTable*, void*);
 
 IndexSlot* index_put_entry(IndexTable*, void*);
+/* Like index_put_entry() but returns NULL instead of aborting the node when
+   the table is full, so the caller can raise a catchable error. */
+IndexSlot* index_put_entry_may_fail(IndexTable*, void*);
 
 /* Erase all entries with index 'ix' and higher
 */

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -673,7 +673,7 @@ erts_open_driver(erts_driver_t* driver,	/* Pointer to driver. */
     if (ERTS_IS_P_TRACED_FL(port, F_TRACE_PORTS)) {
 	trace_port_open(port,
 			pid,
-			erts_atom_put((byte *) port->name,
+			erts_atom_put_or_die((byte *) port->name,
 				      sys_strlen(port->name),
 				      ERTS_ATOM_ENC_LATIN1,
 				      1));
@@ -2937,7 +2937,7 @@ erl_drv_init_ack(ErlDrvPort ix, ErlDrvData res) {
             break;
         case -2: {
             char *str = erl_errno_id(errno);
-            resp = erts_atom_put((byte *) str, sys_strlen(str),
+            resp = erts_atom_put_or_die((byte *) str, sys_strlen(str),
                                  ERTS_ATOM_ENC_LATIN1, 1);
             break;
         }
@@ -7238,7 +7238,7 @@ int driver_exit(ErlDrvPort ix, int err)
         return driver_failure_term(ix, am_normal, 0);
     else {
         char* err_str = erl_errno_id(err);
-        Eterm am_err = erts_atom_put((byte *) err_str, sys_strlen(err_str),
+        Eterm am_err = erts_atom_put_or_die((byte *) err_str, sys_strlen(err_str),
 				     ERTS_ATOM_ENC_LATIN1, 1);
         return driver_failure_term(ix, am_err, 0);
     }
@@ -7253,7 +7253,7 @@ int driver_failure(ErlDrvPort ix, int code)
 int driver_failure_atom(ErlDrvPort ix, char* string)
 {
     return driver_failure_term(ix,
-			       erts_atom_put((byte *) string,
+			       erts_atom_put_or_die((byte *) string,
 					     sys_strlen(string),
 					     ERTS_ATOM_ENC_LATIN1,
 					     1),
@@ -7274,7 +7274,7 @@ int driver_failure_eof(ErlDrvPort ix)
 
 ErlDrvTermData driver_mk_atom(char* string)
 {
-    Eterm am = erts_atom_put((byte *) string,
+    Eterm am = erts_atom_put_or_die((byte *) string,
 			     sys_strlen(string),
 			     ERTS_ATOM_ENC_LATIN1,
 			     1);
@@ -7549,7 +7549,7 @@ no_stop_select_callback(ErlDrvEvent event, void* private)
 static int
 init_driver(erts_driver_t *drv, ErlDrvEntry *de, DE_Handle *handle)
 {
-    drv->name_atom = erts_atom_put((byte*)de->driver_name,
+    drv->name_atom = erts_atom_put_or_die((byte*)de->driver_name,
                                    sys_strlen(de->driver_name),
                                    ERTS_ATOM_ENC_LATIN1, 1);
     drv->name = de->driver_name;

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -1043,7 +1043,13 @@ int beam_load_finish_emit(LoaderState *stp) {
         ERTS_INIT_OFF_HEAP(&code_off_heap);
 
         lit_asize = ERTS_LITERAL_AREA_ALLOC_SIZE(tot_lit_size);
-        literal_area = erts_alloc(ERTS_ALC_T_LITERAL, lit_asize);
+        literal_area = erts_alloc_fnf(ERTS_ALC_T_LITERAL, lit_asize);
+        if (literal_area == NULL) {
+            /* Out of memory for this module's literals. Fail the load with a
+               catchable error rather than aborting the whole node; nothing
+               has been committed to the code tables yet at this point. */
+            BeamLoadError0(stp, "out of memory allocating module literals");
+        }
         ptr = &literal_area->start[0];
         literal_area->end = ptr + tot_lit_size;
 

--- a/erts/emulator/beam/module.c
+++ b/erts/emulator/beam/module.c
@@ -256,6 +256,14 @@ int module_code_size(ErtsCodeIndex code_ix)
     return module_tables[code_ix].entries;
 }
 
+/* Staging-table (the table a load inserts into) capacity check for the
+ * loader pre-flight; see beam_load.c. */
+int erts_module_table_would_fit(int need)
+{
+    return erts_index_table_would_fit(&module_tables[erts_staging_code_ix()],
+                                      need);
+}
+
 int module_table_sz(void)
 {
     return erts_atomic_read_nob(&tot_module_bytes);

--- a/erts/emulator/beam/module.h
+++ b/erts/emulator/beam/module.h
@@ -82,6 +82,7 @@ void module_info(fmtfn_t, void *);
 
 Module *module_code(int, ErtsCodeIndex);
 int module_code_size(ErtsCodeIndex);
+int erts_module_table_would_fit(int need);
 int module_table_sz(void);
 
 ERTS_GLB_INLINE void erts_rwlock_old_code(ErtsCodeIndex);

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -467,7 +467,10 @@ Eterm
 erts_bld_atom(Uint **hpp, Uint *szp, char *str)
 {
     if (hpp)
-	return erts_atom_put((byte *) str, sys_strlen(str), ERTS_ATOM_ENC_LATIN1, 1);
+	/* The THE_NON_VALUE below is the sizing-pass sentinel; a build-pass
+	   failure (full atom table) must abort rather than be mistaken for
+	   it, since callers use this result directly as a term. */
+	return erts_atom_put_or_die((byte *) str, sys_strlen(str), ERTS_ATOM_ENC_LATIN1, 1);
     else
 	return THE_NON_VALUE;
 }

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -117,6 +117,7 @@ MODULES= \
 	smoke_test_SUITE \
 	statistics_SUITE \
 	system_info_SUITE \
+	system_limit_SUITE \
 	system_profile_SUITE \
 	time_SUITE \
 	timer_bif_SUITE \

--- a/erts/emulator/test/system_limit_SUITE.erl
+++ b/erts/emulator/test/system_limit_SUITE.erl
@@ -1,0 +1,176 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%% Tests that exhausting a fixed-size runtime table (the atom table and the
+%% code tables: export, module, fun) raises a *catchable* error instead of
+%% aborting the whole node. Each test fills the relevant table on a fresh
+%% peer node and verifies the node survives and stays responsive.
+-module(system_limit_SUITE).
+
+-export([suite/0, all/0]).
+-export([atom_table/1,
+         export_table_decode/1,
+         export_table_make_fun/1,
+         code_load/1]).
+
+%% Entry points executed on the peer node (must be exported for erpc).
+-export([atom_table_body/0,
+         export_decode_body/0,
+         export_make_fun_body/0,
+         code_load_body/1]).
+
+-include_lib("common_test/include/ct.hrl").
+
+suite() ->
+    [{ct_hooks, [ts_install_cth]},
+     {timetrap, {minutes, 3}}].
+
+all() ->
+    [atom_table, export_table_decode, export_table_make_fun, code_load].
+
+%%%
+%%% (1) A full atom table -> catchable system_limit / badarg, node survives.
+%%%
+atom_table(Config) when is_list(Config) ->
+    %% +t chosen well above what a peer node interns at start so it boots and
+    %% loads this module, yet low enough to fill quickly.
+    {ok, Peer, Node} = ?CT_PEER(#{args => ["+t", "32768"]}),
+    run_on_peer(Peer, Node, atom_table_body, []).
+
+atom_table_body() ->
+    %% Pre-warm every path so nothing lazy-loads once the table is full.
+    _ = (catch binary_to_atom(<<"prewarm_b2a">>, utf8)),
+    _ = (catch binary_to_term(term_to_binary(prewarm))),
+    _ = (catch list_to_atom("prewarm_l2a")),
+    _ = fill_atoms(0),
+    %% Table is now at the limit; further atom creation must be catchable.
+    {error, system_limit} = probe(fun() -> list_to_atom(novel("la")) end),
+    {error, system_limit} =
+        probe(fun() -> binary_to_atom(list_to_binary(novel("ba")), utf8) end),
+    %% Decoding a novel atom from the external format -> graceful badarg.
+    {error, badarg} = probe(fun() -> binary_to_term(novel_atom_ext()) end),
+    ok.
+
+fill_atoms(N) ->
+    try list_to_atom("fillatom_" ++ integer_to_list(N)) of
+        _ -> fill_atoms(N + 1)
+    catch
+        error:system_limit -> N
+    end.
+
+novel_atom_ext() ->
+    N = list_to_binary(novel("dec")),
+    <<131, 119, (byte_size(N)):8, N/binary>>.        % SMALL_ATOM_UTF8_EXT
+
+%%%
+%%% (2) A full export table via external-fun decode -> catchable badarg.
+%%%
+export_table_decode(Config) when is_list(Config) ->
+    {ok, Peer, Node} = ?CT_PEER(),
+    run_on_peer(Peer, Node, export_decode_body, []).
+
+export_decode_body() ->
+    Last = fill_exports(0),
+    %% A further novel m:f/A decode must fail with badarg, repeatably.
+    {error, badarg} = probe(fun() -> binary_to_term(mkstub(Last + 1)) end),
+    {error, badarg} = probe(fun() -> binary_to_term(mkstub(Last + 2)) end),
+    ok.
+
+%%%
+%%% (3) A full export table via make_fun/3 and apply/3 -> catchable
+%%%     system_limit (not a node abort, not undef).
+%%%
+export_table_make_fun(Config) when is_list(Config) ->
+    {ok, Peer, Node} = ?CT_PEER(),
+    run_on_peer(Peer, Node, export_make_fun_body, []).
+
+export_make_fun_body() ->
+    N = fill_exports(0),
+    %% Derive the module atoms at runtime so the compiler cannot constant-fold
+    %% make_fun/apply of a literal M:F/A into a compile-time literal fun (which
+    %% would bypass the runtime export-stub path under test).
+    ModMk = list_to_atom("novelmk_" ++ integer_to_list(N)),
+    ModAp = list_to_atom("novelap_" ++ integer_to_list(N)),
+    {error, system_limit} = probe(fun() -> erlang:make_fun(ModMk, f, 0) end),
+    {error, system_limit} = probe(fun() -> apply(ModAp, f, []) end),
+    ok.
+
+%%%
+%%% (4) A full export table -> load_module/code:load_binary refuses with a
+%%%     catchable {error, system_limit} instead of aborting mid-load.
+%%%
+code_load(Config) when is_list(Config) ->
+    Bin = compile_tiny(),
+    {ok, Peer, Node} = ?CT_PEER(),
+    run_on_peer(Peer, Node, code_load_body, [Bin]).
+
+code_load_body(Bin) ->
+    _ = fill_exports(0),
+    {error, system_limit} = code:load_binary(tinymod, "tinymod.beam", Bin),
+    ok.
+
+compile_tiny() ->
+    Forms = [{attribute, 1, module, tinymod},
+             {attribute, 2, export, [{f, 0}]},
+             {function, 3, f, 0, [{clause, 3, [], [], [{atom, 3, ok}]}]}],
+    {ok, tinymod, Bin} = compile:forms(Forms, [binary]),
+    Bin.
+
+%% Run Body on the peer (which must not abort), then confirm the peer is still
+%% alive and accepts new work via an atom-free computation. ?CT_PEER stays at
+%% each call site so its ?FUNCTION_NAME-derived peer name reflects the case.
+run_on_peer(Peer, Node, Body, Args) ->
+    try
+        ok = erpc:call(Node, ?MODULE, Body, Args),
+        4 = erpc:call(Node, erlang, '+', [2, 2])
+    after
+        peer:stop(Peer)
+    end.
+
+%%%
+%%% Shared helpers (run on the peer).
+%%%
+
+%% Fill the export table with distinct m:f/A stubs (varying arity interns only
+%% the atoms 'm' and 'f', so the export table -- not the atom table -- fills).
+%% Returns the arity at which decoding first failed.
+fill_exports(A) ->
+    case (catch binary_to_term(mkstub(A))) of
+        Fun when is_function(Fun) -> fill_exports(A + 1);
+        {'EXIT', {badarg, _}} -> A;
+        Other -> exit({unexpected_fill_result, A, Other})
+    end.
+
+%% EXPORT_EXT external-fun binary for m:f/A.
+mkstub(A) ->
+    <<131, 113, 119, 1, $m, 119, 1, $f, 98, A:32/signed>>.
+
+%% Run F, returning {Class, Reason} if it raises, or 'created' on success.
+probe(F) ->
+    try F() of
+        _ -> created
+    catch
+        C:E -> {C, E}
+    end.
+
+novel(Prefix) ->
+    Prefix ++ "_" ++ integer_to_list(erlang:unique_integer([positive])).


### PR DESCRIPTION
This pull request improves the handling of full atom, export, and fun tables in the BEAM VM, ensuring that user-facing APIs and untrusted input paths now raise catchable `system_limit` errors instead of aborting the node. It also adds pre-flight capacity checks during module loading to avoid aborts when tables are full, and introduces new APIs for safer table operations. The changes touch several subsystems, including atoms, exports, funs, and records.

**Improved error handling for table limits:**

- User-facing BIFs and untrusted input paths (e.g., `list_to_atom/1`, `binary_to_atom/3`, `make_fun/3`, external term decoding) now raise a catchable `system_limit` error when the atom or export table is full, instead of aborting the node. New functions such as `erts_atom_put_or_die()` and `erts_export_get_or_make_stub_or_null()` are introduced to support this. [[1]](diffhunk://#diff-f6fb8a8ecc4950fed5b0ca299a861508bf4966fda3c78c2e47cfe89b32b78012L3226-R3231) [[2]](diffhunk://#diff-f6fb8a8ecc4950fed5b0ca299a861508bf4966fda3c78c2e47cfe89b32b78012L4480-R4488) [[3]](diffhunk://#diff-7ed2b93d4d122da92b6a82a6802ad1e1a7bd49bb148a40c2624d311024e75bf0L5023-R5028) [[4]](diffhunk://#diff-2298f154e4827869c999afb9c55822eb58a611255ee1320bba4344686d88c1b6L85-R85) [[5]](diffhunk://#diff-257a8d4a586de795e949c6473ae97ac5ad3cbf8fc50bf64c788d5b9879e7d885L1984-R1985) [[6]](diffhunk://#diff-257a8d4a586de795e949c6473ae97ac5ad3cbf8fc50bf64c788d5b9879e7d885L2003-R2005)

- Internal call sites that cannot propagate errors (e.g., match-spec compiler, driver APIs) use the new "or_die" APIs to abort as before, preserving prior behavior for non-user-facing code. [[1]](diffhunk://#diff-1a640e8e7229894d5ec3321402bb886eef8f3c560a7d59cf2560f4f9c5eac726R352-R372) [[2]](diffhunk://#diff-ebd818eb87ace15bdfb4f50874325e39e31992e4a1255359ce59f1a774ca56f1L5824-R5827)

**Pre-flight capacity checks for module loading:**

- The loader now checks if the module, export, and fun tables have enough space before attempting to load a module, returning a catchable error if not. This prevents node aborts during code loading due to table exhaustion. [[1]](diffhunk://#diff-2f82de9908c5d9fac56095f587f6e3e75eae1a7d2f507313d652749a3e637ac0R227-R249) [[2]](diffhunk://#diff-e1de9157d9e8689faee0dbbd0179afd765d184cd2d67f55e18f002620798222fR130) [[3]](diffhunk://#diff-38252143926ecbfeb272b4f2b023402f84c405ba8abcd4c5dc5402c5fffcdbe4R124) [[4]](diffhunk://#diff-38252143926ecbfeb272b4f2b023402f84c405ba8abcd4c5dc5402c5fffcdbe4R274-R280) [[5]](diffhunk://#diff-00c6956585b4947ce7834f5e7a8e27f3ec4380d5c996d6f4fc39c265c211285aR105)

**API and implementation changes for table operations:**

- The staged table upsert functions for exports, funs, and records now take a `may_fail` parameter, allowing the caller to specify whether to abort or return `NULL` on failure. Related code paths are updated accordingly. [[1]](diffhunk://#diff-aaf6789f28b1de32045a3ac2dd1dcebb609472afc83250a0832f63f85f291af9L205-R212) [[2]](diffhunk://#diff-aaf6789f28b1de32045a3ac2dd1dcebb609472afc83250a0832f63f85f291af9R251-R260) [[3]](diffhunk://#diff-aaf6789f28b1de32045a3ac2dd1dcebb609472afc83250a0832f63f85f291af9L269-R283) [[4]](diffhunk://#diff-e1de9157d9e8689faee0dbbd0179afd765d184cd2d67f55e18f002620798222fL296-R304) [[5]](diffhunk://#diff-e1de9157d9e8689faee0dbbd0179afd765d184cd2d67f55e18f002620798222fL308-R316) [[6]](diffhunk://#diff-7a57821fe64b4328fe7c456336bb3d63d4cd9b5177c73d5db955df45fa86da5cL177-R177) [[7]](diffhunk://#diff-38252143926ecbfeb272b4f2b023402f84c405ba8abcd4c5dc5402c5fffcdbe4L228-R230) [[8]](diffhunk://#diff-38252143926ecbfeb272b4f2b023402f84c405ba8abcd4c5dc5402c5fffcdbe4L241-R261)

**New error codes and constants:**

- Introduces `ATOM_MAX_LIMIT_ERROR` to distinguish a full atom table from other errors, and propagates it through relevant code paths. [[1]](diffhunk://#diff-09f31acb524632d2864c21e2dc3f890160efb01f32325e4bfbf6d805253f5f70R36) [[2]](diffhunk://#diff-1a640e8e7229894d5ec3321402bb886eef8f3c560a7d59cf2560f4f9c5eac726L331-R334)

**Documentation and code comments:**

- Adds detailed comments explaining the rationale and correct usage of the new APIs and error handling strategies. [[1]](diffhunk://#diff-1a640e8e7229894d5ec3321402bb886eef8f3c560a7d59cf2560f4f9c5eac726R352-R372) [[2]](diffhunk://#diff-38252143926ecbfeb272b4f2b023402f84c405ba8abcd4c5dc5402c5fffcdbe4L241-R261)

These changes collectively make the BEAM VM more robust and user-friendly when system tables reach their limits, and prevent node crashes from user-triggerable conditions.