### PR TITLE
Enhance coverage tools with cth_coverage and clangcov support

### DIFF
--- a/.github/actions/build-base-image/action.yaml
+++ b/.github/actions/build-base-image/action.yaml
@@ -28,6 +28,9 @@ inputs:
     default: '64-bit'
   BUILD_IMAGE:
     default: true
+  COVERAGE:
+    description: 'Build the otp image with native per-line coverage instrumentation (OTP_LINE_COVERAGE=yes). Skips the pre-built caches so that instrumented beams are neither taken from nor saved into them.'
+    default: false
   github_token:
     description: 'GITHUB_TOKEN'
     default: '${{ github.token }}'
@@ -67,9 +70,13 @@ runs:
           INPUTS_TYPE: ${{ inputs.TYPE }}
         run: .github/scripts/build-base-image.sh "${INPUTS_BASE_BRANCH}" "${INPUTS_TYPE}"
 
+      ## For coverage builds the pre-built caches are bypassed (the src cache
+      ## would either provide uninstrumented beams or be re-saved with
+      ## instrumented ones); the otp_prebuilt artifact from the coverage pack
+      ## job is downloaded instead.
       - name: Cache pre-built src
         id: cache-src
-        if: inputs.BUILD_IMAGE == 'true'
+        if: inputs.BUILD_IMAGE == 'true' && inputs.COVERAGE != 'true'
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # ratchet:actions/cache@v5.0.3
         with:
             path: otp_src.tar.gz
@@ -100,10 +107,15 @@ runs:
         shell: bash -eo pipefail {0}
         env:
           INPUTS_TYPE: ${{ inputs.TYPE }}
+          INPUTS_COVERAGE: ${{ inputs.COVERAGE }}
         run: |
           .github/scripts/restore-from-prebuilt.sh `pwd` .github/otp.tar.gz
           rm -f otp_{src,cache}.tar.gz
-          docker build --tag otp \
+          COVERAGE_ARGS=()
+          if [ "$INPUTS_COVERAGE" = "true" ]; then
+            COVERAGE_ARGS=(--build-arg OTP_LINE_COVERAGE=yes)
+          fi
+          docker build --tag otp "${COVERAGE_ARGS[@]}" \
             --build-arg MAKEFLAGS=-j$(($(nproc) + 2)) \
             --file ".github/dockerfiles/Dockerfile.${INPUTS_TYPE}" \
             .github/

--- a/.github/dockerfiles/Dockerfile.64-bit
+++ b/.github/dockerfiles/Dockerfile.64-bit
@@ -26,6 +26,12 @@ ENV MAKEFLAGS=$MAKEFLAGS \
     ERL_TOP=/buildroot/otp \
     PATH="/Erlang ∅⊤℞/bin":/buildroot/otp/bin:$PATH
 
+## When set to "yes" (via --build-arg), the whole OTP is compiled with
+## +line_coverage +force_line_counters so cth_coverage can collect native
+## per-line coverage. Empty by default -> normal, uninstrumented build.
+ARG OTP_LINE_COVERAGE=
+ENV OTP_LINE_COVERAGE=$OTP_LINE_COVERAGE
+
 ARG ARCHIVE=./otp.tar.gz
 COPY $ARCHIVE /buildroot/otp.tar.gz
 RUN cd /buildroot && tar -xzf ./otp.tar.gz

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -253,28 +253,30 @@ jobs:
         with:
             BASE_BRANCH: ${{ needs.pack.outputs.base_branch }}
             COVERAGE: true
-      - name: Build clangcov emulator, run a focused suite on it, convert
+      - name: Build clangcov emulator, exercise it, convert to LCOV
         run: |
           set -x
           mkdir -p native
           ## Build the clang source-based coverage emulator (clangcov) with
-          ## clang, run a focused suite (stdlib) on it via EMU_TYPE=clangcov
-          ## under cth_coverage -- which then also dumps native C + JIT
-          ## coverage into make_test_dir/coverage/native -- and convert the
-          ## profraw to an LCOV tracefile with llvm-cov. The system under
-          ## test keeps the image's line instrumentation, so this run also
-          ## produces BEAM coverdata; only the native LCOV is uploaded here.
+          ## clang (only lib_src + the emulator are needed to run
+          ## -emu_type clangcov), run a workload on it that broadly
+          ## exercises the runtime and the JIT emitter (clangcov_probe.escript
+          ## dumps the native C + JIT coverage via erts_debug:coverage/1), and
+          ## convert the resulting .profraw to an LCOV tracefile with llvm-cov.
+          ## A direct workload is used rather than `make <app>_test`: apps that
+          ## release before testing cannot select -emu_type clangcov from a
+          ## release that does not contain that emulator.
           docker run -v "$PWD/native:/native" otp "
             sudo apt-get update -qq && sudo apt-get install -y -qq clang llvm &&
             ( cd /buildroot/otp/erts/lib_src && make clangcov CC=clang CXX=clang++ ) &&
             ( cd /buildroot/otp/erts/emulator && make clangcov CC=clang CXX=clang++ ) &&
             cd /buildroot/otp &&
-            { make stdlib_test COVERAGE=yes EMU_TYPE=clangcov OTP_LINE_COVERAGE= || true; } &&
-            ./make/native_cov_to_lcov.sh \
-              lib/stdlib/make_test_dir/coverage/native \
-              /buildroot/otp/bin /native/native.info
+            ERL_AFLAGS='-emu_type clangcov' ./bin/escript make/clangcov_probe.escript /buildroot/otp/native_cov &&
+            ./make/native_cov_to_lcov.sh /buildroot/otp/native_cov /buildroot/otp/bin /native/native.info
           "
-          ls -l native/native.info 2>/dev/null || echo "no native coverage produced"
+          ## Fail honestly if no native coverage was produced.
+          test -f native/native.info
+          ls -l native/native.info
       - name: Upload native C/JIT LCOV
         if: ${{ hashFiles('native/native.info') != '' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -28,6 +28,11 @@
 ## single LCOV tracefile (coverage.info) uploaded as the
 ## otp-coverage-lcov artifact.
 ##
+## A separate 'native' job additionally builds the clangcov emulator
+## (clang source-based coverage), runs a focused suite on it under
+## cth_coverage -- which then also dumps the emulator's own C and JIT
+## emitter coverage -- and uploads it as otp-coverage-native-lcov.
+##
 ## The normal push/pull request CI is unaffected: all coverage plumbing
 ## in the reusable workflows and in the build-base-image action is
 ## behind default-false inputs.
@@ -229,3 +234,49 @@ jobs:
         with:
           name: otp-coverage-attribution
           path: coverage/attrib
+
+  native:
+    name: Native C/JIT coverage (clangcov)
+    runs-on: ubuntu-latest
+    ## Independent of the BEAM coverage test/aggregate jobs, so a clang
+    ## build issue here cannot affect them.
+    needs: pack
+    if: ${{ !cancelled() && needs.pack.result == 'success' }}
+    permissions:
+      contents: read   # actions/checkout + ./.github/actions/build-base-image
+      actions:  write  # actions/upload-artifact
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-base-image
+        with:
+            BASE_BRANCH: ${{ needs.pack.outputs.base_branch }}
+            COVERAGE: true
+      - name: Build clangcov emulator, run a focused suite on it, convert
+        run: |
+          set -x
+          mkdir -p native
+          ## Build the clang source-based coverage emulator (clangcov) with
+          ## clang, run a focused suite (stdlib) on it via EMU_TYPE=clangcov
+          ## under cth_coverage -- which then also dumps native C + JIT
+          ## coverage into make_test_dir/coverage/native -- and convert the
+          ## profraw to an LCOV tracefile with llvm-cov. The system under
+          ## test keeps the image's line instrumentation, so this run also
+          ## produces BEAM coverdata; only the native LCOV is uploaded here.
+          docker run -v "$PWD/native:/native" otp "
+            sudo apt-get update -qq && sudo apt-get install -y -qq clang llvm &&
+            ( cd /buildroot/otp/erts && make clangcov CC=clang CXX=clang++ ) &&
+            cd /buildroot/otp &&
+            { make stdlib_test COVERAGE=yes EMU_TYPE=clangcov OTP_LINE_COVERAGE= || true; } &&
+            ./make/native_cov_to_lcov.sh \
+              lib/stdlib/make_test_dir/coverage/native \
+              /buildroot/otp/bin /native/native.info
+          "
+          ls -l native/native.info 2>/dev/null || echo "no native coverage produced"
+      - name: Upload native C/JIT LCOV
+        if: ${{ hashFiles('native/native.info') != '' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0
+        with:
+          name: otp-coverage-native-lcov
+          path: native/native.info

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -175,8 +175,21 @@ jobs:
           docker run -v "$PWD/coverage:/cov" otp \
             "escript /cov/aggregate.escript /cov/coverage.info /cov/results"
           ls -l coverage/coverage.info
+          ## Render a browsable HTML report from the LCOV tracefile. genhtml
+          ## runs inside the image because the SF: paths in coverage.info are
+          ## the in-container source paths (/buildroot/otp/lib/*/src/*.erl);
+          ## --prefix trims that lead from the displayed tree. lcov is installed
+          ## on demand so the shared base image is left untouched.
+          docker run -v "$PWD/coverage:/cov" otp \
+            "(command -v genhtml >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y -qq lcov)) && genhtml /cov/coverage.info --output-directory /cov/html --prefix /buildroot/otp --title 'Erlang/OTP line coverage' --legend --quiet --ignore-errors source"
+          ls -l coverage/html/index.html
       - name: Upload LCOV tracefile
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0
         with:
           name: otp-coverage-lcov
           path: coverage/coverage.info
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0
+        with:
+          name: otp-coverage-html
+          path: coverage/html

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,182 @@
+# %CopyrightBegin%
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright Ericsson AB 2026. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# %CopyrightEnd%
+
+##
+## Scheduled (and manually dispatched) per-testcase line-coverage run.
+##
+## Builds Erlang/OTP with native line instrumentation
+## (OTP_LINE_COVERAGE=yes, i.e. +line_coverage +force_line_counters),
+## runs the test suites with the cth_coverage CT hook enabled, and
+## aggregates the per-testcase coverdata from all test jobs into a
+## single LCOV tracefile (coverage.info) uploaded as the
+## otp-coverage-lcov artifact.
+##
+## The normal push/pull request CI is unaffected: all coverage plumbing
+## in the reusable workflows and in the build-base-image action is
+## behind default-false inputs.
+##
+
+name: Coverage of Erlang/OTP
+
+on:
+  workflow_dispatch:
+  schedule:
+      ## Weekly, Sundays at 03:00 UTC
+      - cron: 0 3 * * 0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    uses: ./.github/workflows/reusable-setup.yaml
+
+  pack:
+    name: Build Erlang/OTP (64-bit, line coverage)
+    needs: setup
+    permissions:
+      contents: read
+      actions: write
+    uses: ./.github/workflows/reusable-pack.yaml
+    with:
+      base_branch:          ${{ needs.setup.outputs.base_branch }}
+      ## Always do a full build: the coverage image must not reuse any
+      ## uninstrumented pre-built beams, and we want the full app list
+      ## in the 'changes' output so that all test suites are run.
+      ## (The expression form keeps the value typed as a string.)
+      full_build_and_check: ${{ 'true' }}
+      bypass_erlang_repo:   false
+      coverage:             true
+
+  test:
+    name: Test Erlang/OTP (coverage)
+    needs: pack
+    if: needs.pack.outputs.changes != '[]'
+    permissions:
+      contents: read
+      actions:  write
+    uses: ./.github/workflows/reusable-test.yaml
+    with:
+      changes:     ${{ needs.pack.outputs.changes }}
+      base_branch: ${{ needs.pack.outputs.base_branch }}
+      coverage:    true
+
+  aggregate:
+    name: Aggregate coverage into LCOV
+    runs-on: ubuntu-latest
+    ## Run even if some test jobs failed so that whatever coverage was
+    ## collected still ends up in the artifact.
+    if: ${{ !cancelled() && needs.pack.result == 'success' }}
+    needs:
+      - pack
+      - test
+    permissions:
+      contents: read   # actions/checkout + ./.github/actions/build-base-image
+      actions:  write  # actions/download-artifact + actions/upload-artifact
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      ## Re-create the otp image (from this run's otp_prebuilt artifact)
+      ## so that ct_cover_to_lcov from this source tree can be used.
+      - uses: ./.github/actions/build-base-image
+        with:
+            BASE_BRANCH: ${{ needs.pack.outputs.base_branch }}
+            COVERAGE: true
+      - name: Download test results
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # ratchet:actions/download-artifact@v6.0.0
+        with:
+          pattern: "*_test_results"
+          path: test_results
+      - name: Aggregate coverage
+        run: |
+          set -x
+          mkdir -p coverage/results
+          ## Each test job tars its make_test_dir; the cth_coverage output
+          ## (per-testcase *.coverdata + coverage.manifest) is in
+          ## make_test_dir/coverage. Unpack only that part of each tarball.
+          shopt -s nullglob
+          for tarball in test_results/*/*.tar.gz; do
+            name=$(basename "$tarball" .tar.gz)
+            mkdir -p "coverage/results/$name"
+            tar -xzf "$tarball" -C "coverage/results/$name" make_test_dir/coverage ||
+              echo "No coverage data in $tarball"
+          done
+          cat > coverage/aggregate.escript <<'ESCRIPT'
+          #!/usr/bin/env escript
+          %% -*- erlang -*-
+          %%! -pa /buildroot/otp/lib/common_test/ebin
+
+          %% Merge every *.coverdata file (per-testcase native line coverage
+          %% written by cth_coverage) found under Root into one LCOV
+          %% tracefile. The per-node coverage.manifest files are concatenated
+          %% into one manifest so that instrumented-but-unexecuted lines are
+          %% emitted with count 0 (ct_cover_to_lcov unions duplicate module
+          %% entries).
+          main([OutFile, Root]) ->
+              CoverData = filelib:wildcard(filename:join(Root, "**/*.coverdata")),
+              Manifests = filelib:wildcard(filename:join(Root, "**/coverage.manifest")),
+              io:format("Aggregating ~w coverdata files and ~w manifests~n",
+                        [length(CoverData), length(Manifests)]),
+              case CoverData of
+                  [] ->
+                      io:format(standard_error,
+                                "error: no .coverdata files found under ~ts~n",
+                                [Root]),
+                      halt(1);
+                  _ ->
+                      ok
+              end,
+              Opts =
+                  case Manifests of
+                      [] ->
+                          [];
+                      _ ->
+                          Manifest =
+                              lists:append(
+                                [begin
+                                     {ok, Bin} = file:read_file(F),
+                                     binary_to_term(Bin)
+                                 end || F <- Manifests]),
+                          MergedFile = filename:join(Root, "merged.manifest"),
+                          ok = file:write_file(MergedFile, term_to_binary(Manifest)),
+                          [{manifest, MergedFile}]
+                  end,
+              case ct_cover_to_lcov:convert(CoverData, OutFile, Opts) of
+                  ok ->
+                      ok;
+                  {error, Reason} ->
+                      io:format(standard_error,
+                                "ct_cover_to_lcov failed: ~tp~n", [Reason]),
+                      halt(1)
+              end.
+          ESCRIPT
+          docker run -v "$PWD/coverage:/cov" otp \
+            "escript /cov/aggregate.escript /cov/coverage.info /cov/results"
+          ls -l coverage/coverage.info
+      - name: Upload LCOV tracefile
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0
+        with:
+          name: otp-coverage-lcov
+          path: coverage/coverage.info

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -83,7 +83,7 @@ jobs:
       coverage:    true
 
   aggregate:
-    name: Aggregate coverage into LCOV
+    name: Aggregate coverage (LCOV + HTML + attribution)
     runs-on: ubuntu-latest
     ## Run even if some test jobs failed so that whatever coverage was
     ## collected still ends up in the artifact.
@@ -92,8 +92,9 @@ jobs:
       - pack
       - test
     permissions:
-      contents: read   # actions/checkout + ./.github/actions/build-base-image
-      actions:  write  # actions/download-artifact + actions/upload-artifact
+      contents: read    # actions/checkout + ./.github/actions/build-base-image
+      actions:  write   # actions/download-artifact + actions/upload-artifact
+      id-token: write   # Codecov OIDC (tokenless upload for public repos)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
         with:
@@ -163,18 +164,31 @@ jobs:
                           ok = file:write_file(MergedFile, term_to_binary(Manifest)),
                           [{manifest, MergedFile}]
                   end,
-              case ct_cover_to_lcov:convert(CoverData, OutFile, Opts) of
+              ok = case ct_cover_to_lcov:convert(CoverData, OutFile, Opts) of
+                       ok ->
+                           ok;
+                       {error, LReason} ->
+                           io:format(standard_error,
+                                     "ct_cover_to_lcov failed: ~tp~n", [LReason]),
+                           halt(1)
+                   end,
+              %% Same inputs, but keeping the per-testcase dimension: an
+              %% interactive report of which testcases cover each line.
+              AttribDir = filename:join(filename:dirname(OutFile), "attrib"),
+              case ct_cover_to_html:convert(
+                     CoverData, AttribDir,
+                     [{title, "Erlang/OTP coverage attribution"} | Opts]) of
                   ok ->
-                      ok;
-                  {error, Reason} ->
+                      io:format("Wrote attribution report to ~ts~n", [AttribDir]);
+                  {error, HReason} ->
                       io:format(standard_error,
-                                "ct_cover_to_lcov failed: ~tp~n", [Reason]),
+                                "ct_cover_to_html failed: ~tp~n", [HReason]),
                       halt(1)
               end.
           ESCRIPT
           docker run -v "$PWD/coverage:/cov" otp \
             "escript /cov/aggregate.escript /cov/coverage.info /cov/results"
-          ls -l coverage/coverage.info
+          ls -l coverage/coverage.info coverage/attrib/index.html
           ## Render a browsable HTML report from the LCOV tracefile. genhtml
           ## runs inside the image because the SF: paths in coverage.info are
           ## the in-container source paths (/buildroot/otp/lib/*/src/*.erl);
@@ -188,8 +202,26 @@ jobs:
         with:
           name: otp-coverage-lcov
           path: coverage/coverage.info
+      ## Feed the same LCOV tracefile to Codecov for dashboards, trends and
+      ## PR checks. Never fail the coverage leg on a Codecov hiccup or a
+      ## missing token; the artifacts are the source of truth. Needs the
+      ## CODECOV_TOKEN secret (or the Codecov app, tokenless via OIDC) set
+      ## on the repository for the upload to be accepted.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # ratchet:codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: coverage/coverage.info
+          disable_search: true
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0
         with:
           name: otp-coverage-html
           path: coverage/html
+      - name: Upload per-testcase attribution report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6.0.0
+        with:
+          name: otp-coverage-attribution
+          path: coverage/attrib

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -266,7 +266,8 @@ jobs:
           ## produces BEAM coverdata; only the native LCOV is uploaded here.
           docker run -v "$PWD/native:/native" otp "
             sudo apt-get update -qq && sudo apt-get install -y -qq clang llvm &&
-            ( cd /buildroot/otp/erts && make clangcov CC=clang CXX=clang++ ) &&
+            ( cd /buildroot/otp/erts/lib_src && make clangcov CC=clang CXX=clang++ ) &&
+            ( cd /buildroot/otp/erts/emulator && make clangcov CC=clang CXX=clang++ ) &&
             cd /buildroot/otp &&
             { make stdlib_test COVERAGE=yes EMU_TYPE=clangcov OTP_LINE_COVERAGE= || true; } &&
             ./make/native_cov_to_lcov.sh \

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,9 +29,9 @@
 ## otp-coverage-lcov artifact.
 ##
 ## A separate 'native' job additionally builds the clangcov emulator
-## (clang source-based coverage), runs a focused suite on it under
-## cth_coverage -- which then also dumps the emulator's own C and JIT
-## emitter coverage -- and uploads it as otp-coverage-native-lcov.
+## (clang source-based coverage), exercises it with a workload that dumps
+## the emulator's own C and JIT-emitter coverage (erts_debug:coverage/1),
+## and uploads it as the otp-coverage-native-lcov artifact.
 ##
 ## The normal push/pull request CI is unaffected: all coverage plumbing
 ## in the reusable workflows and in the build-base-image action is

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -175,9 +175,13 @@ jobs:
               %% Same inputs, but keeping the per-testcase dimension: an
               %% interactive report of which testcases cover each line.
               AttribDir = filename:join(filename:dirname(OutFile), "attrib"),
+              %% A hot line (e.g. in lists) is reached by huge numbers of
+              %% testcases across apps; list at most 5 as examples (the true
+              %% count is still shown) to keep the whole-tree report small.
               case ct_cover_to_html:convert(
                      CoverData, AttribDir,
-                     [{title, "Erlang/OTP coverage attribution"} | Opts]) of
+                     [{title, "Erlang/OTP coverage attribution"},
+                      {max_tests_per_line, 5} | Opts]) of
                   ok ->
                       io:format("Wrote attribution report to ~ts~n", [AttribDir]);
                   {error, HReason} ->

--- a/.github/workflows/reusable-pack.yaml
+++ b/.github/workflows/reusable-pack.yaml
@@ -34,6 +34,11 @@ on:
         required: true
         type: boolean
         description: "Bypasses checks of github.repository being 'erlang/otp'. Used for testing in forks"
+      coverage:
+        required: false
+        type: boolean
+        default: false
+        description: "Build the otp image with native per-line coverage instrumentation (OTP_LINE_COVERAGE=yes)"
     outputs:
       changes:
         description: "changed apps"
@@ -120,7 +125,11 @@ jobs:
             echo "value=false" >> $GITHUB_OUTPUT
           fi
 
+      ## The two pre-built cache steps are skipped for coverage builds: a
+      ## coverage build must neither reuse uninstrumented pre-built beams nor
+      ## re-save instrumented beams into the caches used by the normal CI.
       - name: Cache pre-built src
+        if: ${{ !inputs.coverage }}
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # ratchet:actions/cache@v5.0.3
         with:
             path: otp_src.tar.gz
@@ -129,6 +138,7 @@ jobs:
                 prebuilt-src-${{ github.base_ref }}-${{ github.event.pull_request.base.sha }}
 
       - name: Cache pre-built binaries
+        if: ${{ !inputs.coverage }}
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # ratchet:actions/cache@v5.0.3
         with:
             path: otp_cache.tar.gz
@@ -182,8 +192,14 @@ jobs:
           path: .github/otp.tar.gz
 
       - name: Build image
+        env:
+          COVERAGE: ${{ inputs.coverage }}
         run: |
-          docker build --tag otp \
+          COVERAGE_ARGS=()
+          if [ "$COVERAGE" = "true" ]; then
+            COVERAGE_ARGS=(--build-arg OTP_LINE_COVERAGE=yes)
+          fi
+          docker build --tag otp "${COVERAGE_ARGS[@]}" \
             --build-arg MAKEFLAGS=-j$(($(nproc) + 2)) \
             --file ".github/dockerfiles/Dockerfile.64-bit" \
             .github/

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -88,12 +88,21 @@ jobs:
           sudo bash -c "echo 'core.%p' > /proc/sys/kernel/core_pattern"
           EXTRA_ARGS="-ct_hooks cth_surefire [{path,\"/buildroot/otp/$DIR/make_test_dir/${MATRIX_TYPE}_junit.xml\"}]"
           COVERAGE_ENV=()
+          TEST_MAKE_COV=""
           if [ "$COVERAGE" = "true" ]; then
             ## Collect native per-testcase line coverage. The coverage dir is
             ## placed inside the mounted make_test_dir so that the coverdata
             ## rides along in the ${MATRIX_TYPE}_test_results.tar.gz artifact.
             EXTRA_ARGS="$EXTRA_ARGS and cth_coverage"
             COVERAGE_ENV=(-e "CT_COVERAGE_DIR=/buildroot/otp/$DIR/make_test_dir/coverage")
+            ## Only the system under test is line-coverage instrumented (built
+            ## into the image). The test suites themselves must NOT be: their
+            ## own coverage is not wanted, and instrumenting generated
+            ## compiler-test variants (e.g. *_no_type_opt_SUITE) trips a compiler
+            ## bug in the +no_type_opt / +line_coverage combination. Turn the
+            ## flag off for the test-suite compilation only (the system under
+            ## test was already built with it in the image).
+            TEST_MAKE_COV=" OTP_LINE_COVERAGE="
           fi
           docker run --ulimit core=-1 --ulimit nofile=5000:5000 --pids-limit 1024 \
             -e CTRUN_TIMEOUT=90 -e SPEC_POSTFIX=gh \
@@ -102,7 +111,7 @@ jobs:
             "${COVERAGE_ENV[@]}" \
             -v "$PWD/make_test_dir:/buildroot/otp/$DIR/make_test_dir" \
             -v "$PWD/scripts:/buildroot/otp/scripts" \
-            otp "./otp_build download_gdb_tools && make emulator && make TYPE=${TYPE} && make ${APP}_test TYPE=${TYPE}"
+            otp "./otp_build download_gdb_tools && make emulator && make TYPE=${TYPE} && make ${APP}_test TYPE=${TYPE}${TEST_MAKE_COV}"
           ## Rename os_mon to debug for debug build
           if [ "$APP" != "${MATRIX_TYPE}" ]; then
             mv make_test_dir/${APP}_test "make_test_dir/${MATRIX_TYPE}_test"

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -30,6 +30,11 @@ on:
       changes:
         required: true
         type: string
+      coverage:
+        required: false
+        type: boolean
+        default: false
+        description: "Collect native per-testcase line coverage with the cth_coverage CT hook (needs an image built with OTP_LINE_COVERAGE=yes)"
 
 env:
   BASE_BRANCH: ${{ inputs.base_branch }}
@@ -58,10 +63,12 @@ jobs:
       - uses: ./.github/actions/build-base-image
         with:
             BASE_BRANCH: ${{ env.BASE_BRANCH }}
+            COVERAGE: ${{ inputs.coverage }}
       - name: Run tests
         id: run-tests
         env:
           MATRIX_TYPE: ${{ matrix.type }}
+          COVERAGE: ${{ inputs.coverage }}
         run: |
           set -x
           mkdir $PWD/make_test_dir
@@ -79,10 +86,20 @@ jobs:
           ! sudo service apport stop
           sudo sysctl -w dev.tty.legacy_tiocsti=1
           sudo bash -c "echo 'core.%p' > /proc/sys/kernel/core_pattern"
+          EXTRA_ARGS="-ct_hooks cth_surefire [{path,\"/buildroot/otp/$DIR/make_test_dir/${MATRIX_TYPE}_junit.xml\"}]"
+          COVERAGE_ENV=()
+          if [ "$COVERAGE" = "true" ]; then
+            ## Collect native per-testcase line coverage. The coverage dir is
+            ## placed inside the mounted make_test_dir so that the coverdata
+            ## rides along in the ${MATRIX_TYPE}_test_results.tar.gz artifact.
+            EXTRA_ARGS="$EXTRA_ARGS and cth_coverage"
+            COVERAGE_ENV=(-e "CT_COVERAGE_DIR=/buildroot/otp/$DIR/make_test_dir/coverage")
+          fi
           docker run --ulimit core=-1 --ulimit nofile=5000:5000 --pids-limit 1024 \
             -e CTRUN_TIMEOUT=90 -e SPEC_POSTFIX=gh \
             -e TEST_NEEDS_RELEASE=true -e "RELEASE_ROOT=/buildroot/otp/Erlang ∅⊤℞" \
-            -e EXTRA_ARGS="-ct_hooks cth_surefire [{path,\"/buildroot/otp/$DIR/make_test_dir/${MATRIX_TYPE}_junit.xml\"}]" \
+            -e EXTRA_ARGS="$EXTRA_ARGS" \
+            "${COVERAGE_ENV[@]}" \
             -v "$PWD/make_test_dir:/buildroot/otp/$DIR/make_test_dir" \
             -v "$PWD/scripts:/buildroot/otp/scripts" \
             otp "./otp_build download_gdb_tools && make emulator && make TYPE=${TYPE} && make ${APP}_test TYPE=${TYPE}"

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -408,6 +408,68 @@ dialyzer errors and many more things.
 
 There is a detailed description about how to run tests in [TESTING.md](TESTING.md).
 
+### Test coverage
+
+Erlang/OTP can collect native, per-testcase line coverage: for every test case,
+exactly which lines of the system under test it executed. Coverage is captured
+by the `cth_coverage` Common Test hook and can be turned into an LCOV tracefile
+or an interactive HTML report that shows which test cases cover each line.
+
+Coverage requires the JIT (`code:coverage_support()` must return `true`).
+
+**1. Build the system under test with instrumentation.** Only the system under
+test is instrumented, not the test suites:
+
+```bash
+# from $ERL_TOP -- instruments all of lib/*/src
+make OTP_LINE_COVERAGE=yes
+```
+
+`OTP_LINE_COVERAGE=yes` adds `+line_coverage +force_line_counters`. Only
+recompiled modules are instrumented, so if the tree is already built either do a
+clean build or instrument just the application you are interested in:
+
+```bash
+(cd lib/stdlib && make clean && make OTP_LINE_COVERAGE=yes)
+```
+
+Do **not** `export` `OTP_LINE_COVERAGE`; passing it only to the build above keeps
+the test suites themselves uninstrumented.
+
+**2. Run the tests with coverage.** `COVERAGE=yes` installs the `cth_coverage`
+hook and writes one coverdata file per test case:
+
+```bash
+make stdlib_test COVERAGE=yes
+# or, from within an application:  (cd lib/stdlib && make test COVERAGE=yes)
+```
+
+The coverdata, plus a `coverage.manifest` listing all instrumented lines, is
+written to `lib/stdlib/make_test_dir/coverage` (override with `CT_COVERAGE_DIR`).
+
+**3. Generate the reports:**
+
+```bash
+(cd lib/stdlib && make coverage_report)
+```
+
+This writes, under `make_test_dir/coverage`:
+
+* `coverage.info` -- an LCOV tracefile. Feed it to `genhtml`, to a coverage
+  service such as Codecov, or to the VS Code
+  [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters)
+  extension for inline gutter highlighting.
+* `html/index.html` -- the per-testcase **attribution** report: click any
+  covered line to see which test cases executed it, or type a test-case name to
+  highlight the lines it covers.
+
+**Whole-tree coverage in CI.** The `Coverage of Erlang/OTP` GitHub Actions
+workflow (`.github/workflows/coverage.yaml`, run weekly or via
+`workflow_dispatch`) builds all of Erlang/OTP instrumented, runs every
+application's tests under `cth_coverage`, and uploads the `otp-coverage-lcov`,
+`otp-coverage-html` and `otp-coverage-attribution` artifacts. When a
+`CODECOV_TOKEN` secret is configured it also pushes the tracefile to Codecov.
+
 ## Writing and building documentation
 
 Most of the Erlang/OTP documentation is written using markdown, either directly

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -98,6 +98,18 @@ CONFIGURE_CXXFLAGS = @CXXFLAGS@
 DEBUG_CFLAGS = @DEBUG_CFLAGS@
 DEBUG_CXXFLAGS = @DEBUG_CXXFLAGS@
 
+# clangcov compiles the bundled zstd/zlib libraries with clang via
+# $(CONFIGURE_CFLAGS); strip the GCC-only flags a gcc-configured build
+# carries (-Wtrampolines) and the blanket -Werror so they build under
+# clang (the specific -Werror=<name> flags are kept). The emulator's own
+# objects are handled in the clangcov TYPE_FLAGS below.
+ifeq ($(TYPE),clangcov)
+CONFIGURE_CFLAGS := $(filter-out -Werror -Wtrampolines,$(CONFIGURE_CFLAGS))
+CONFIGURE_CXXFLAGS := $(filter-out -Werror -Wtrampolines,$(CONFIGURE_CXXFLAGS))
+DEBUG_CFLAGS := $(filter-out -Werror -Wtrampolines,$(DEBUG_CFLAGS))
+DEBUG_CXXFLAGS := $(filter-out -Werror -Wtrampolines,$(DEBUG_CXXFLAGS))
+endif
+
 #
 # Run this make file with TYPE set to the type of emulator you want.
 # Different versions of the emulator for different uses. The default

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -98,16 +98,19 @@ CONFIGURE_CXXFLAGS = @CXXFLAGS@
 DEBUG_CFLAGS = @DEBUG_CFLAGS@
 DEBUG_CXXFLAGS = @DEBUG_CXXFLAGS@
 
-# clangcov compiles the bundled zstd/zlib libraries with clang via
-# $(CONFIGURE_CFLAGS); strip the GCC-only flags a gcc-configured build
-# carries (-Wtrampolines) and the blanket -Werror so they build under
-# clang (the specific -Werror=<name> flags are kept). The emulator's own
-# objects are handled in the clangcov TYPE_FLAGS below.
+# Flags a gcc-configured coverage build carries that the clang (clangcov)
+# build must drop: GCC-only warnings (-Wtrampolines), the blanket -Werror
+# (the specific -Werror=<name> flags are kept), and UBSan
+# (-fsanitize=signed-integer-overflow), whose runtime is not linked into a
+# coverage build. Applied to CONFIGURE_/DEBUG_ flags so the bundled
+# libraries (zstd, zlib) that compile with $(CONFIGURE_CFLAGS) build too;
+# the emulator's own objects filter the same set in TYPE_FLAGS below.
+CLANGCOV_FILTER_OUT = -Werror -Wtrampolines -fsanitize=signed-integer-overflow
 ifeq ($(TYPE),clangcov)
-CONFIGURE_CFLAGS := $(filter-out -Werror -Wtrampolines,$(CONFIGURE_CFLAGS))
-CONFIGURE_CXXFLAGS := $(filter-out -Werror -Wtrampolines,$(CONFIGURE_CXXFLAGS))
-DEBUG_CFLAGS := $(filter-out -Werror -Wtrampolines,$(DEBUG_CFLAGS))
-DEBUG_CXXFLAGS := $(filter-out -Werror -Wtrampolines,$(DEBUG_CXXFLAGS))
+CONFIGURE_CFLAGS := $(filter-out $(CLANGCOV_FILTER_OUT),$(CONFIGURE_CFLAGS))
+CONFIGURE_CXXFLAGS := $(filter-out $(CLANGCOV_FILTER_OUT),$(CONFIGURE_CXXFLAGS))
+DEBUG_CFLAGS := $(filter-out $(CLANGCOV_FILTER_OUT),$(DEBUG_CFLAGS))
+DEBUG_CXXFLAGS := $(filter-out $(CLANGCOV_FILTER_OUT),$(DEBUG_CXXFLAGS))
 endif
 
 #
@@ -182,8 +185,8 @@ TYPEMARKER = .clangcov
 # gcc-configured @CFLAGS@ may carry (e.g. a hardening -Wtrampolines) and
 # the blanket -Werror that would make clang's "unknown warning option"
 # fatal. Specific -Werror=<name> flags are kept (clang supports them).
-TYPE_FLAGS = $(filter-out -Werror -Wtrampolines,@CFLAGS@) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
-TYPE_CXXFLAGS = $(filter-out -Werror -Wtrampolines,@CXXFLAGS@)
+TYPE_FLAGS = $(filter-out $(CLANGCOV_FILTER_OUT),@CFLAGS@) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
+TYPE_CXXFLAGS = $(filter-out $(CLANGCOV_FILTER_OUT),@CXXFLAGS@)
 LDFLAGS += -fprofile-instr-generate
 else
 

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -158,6 +158,19 @@ endif
 ENABLE_ALLOC_TYPE_VARS += debug
 else
 
+ifeq ($(TYPE),clangcov)
+TYPEMARKER = .clangcov
+# Clang source-based coverage. Unlike gcov (which forces -O0), this stays
+# optimized, so the JIT emitter (C++) and the rest of the emulator are
+# covered under real optimization. -fprofile-instr-generate/-fcoverage-mapping
+# instrument at compile time; the LLVM profile runtime is pulled in at link
+# via -fprofile-instr-generate (LDFLAGS below). Coverage flags live in
+# TYPE_FLAGS, which feeds both CFLAGS and (via CFLAGS) CXXFLAGS.
+TYPE_FLAGS = @CFLAGS@ -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
+TYPE_CXXFLAGS = @CXXFLAGS@
+LDFLAGS += -fprofile-instr-generate
+else
+
 ifeq ($(TYPE),valgrind)
 TYPEMARKER = .valgrind
 TYPE_FLAGS = @DEBUG_CFLAGS@ -DVALGRIND -DNO_JUMP_TABLE @NO_MAYBE_UNINITIALIZED@
@@ -208,6 +221,7 @@ override TYPE=opt
 TYPEMARKER =
 TYPE_FLAGS = @CFLAGS@
 TYPE_CXXFLAGS = @CXXFLAGS@
+endif
 endif
 endif
 endif

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -166,8 +166,12 @@ TYPEMARKER = .clangcov
 # instrument at compile time; the LLVM profile runtime is pulled in at link
 # via -fprofile-instr-generate (LDFLAGS below). Coverage flags live in
 # TYPE_FLAGS, which feeds both CFLAGS and (via CFLAGS) CXXFLAGS.
-TYPE_FLAGS = @CFLAGS@ -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
-TYPE_CXXFLAGS = @CXXFLAGS@
+# clangcov always compiles with clang; drop GCC-only flags that a
+# gcc-configured @CFLAGS@ may carry (e.g. a hardening -Wtrampolines) and
+# the blanket -Werror that would make clang's "unknown warning option"
+# fatal. Specific -Werror=<name> flags are kept (clang supports them).
+TYPE_FLAGS = $(filter-out -Werror -Wtrampolines,@CFLAGS@) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
+TYPE_CXXFLAGS = $(filter-out -Werror -Wtrampolines,@CXXFLAGS@)
 LDFLAGS += -fprofile-instr-generate
 else
 

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -256,6 +256,7 @@ atom dotall
 atom driver
 atom driver_options
 atom dsend_continue_trap
+atom dump
 atom duplicate_bag
 atom duplicated
 atom dupnames
@@ -527,6 +528,7 @@ atom not_loaded_by_this_process
 atom not_pending
 atom not_owner
 atom not_purged
+atom not_supported
 atom notalive
 atom notbol
 atom noteol

--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -50,6 +50,12 @@
 # define HEXF "%08bpX"
 #endif
 
+#ifdef ERTS_GCOV
+/* Provided by libgcov, but not declared in any header. */
+extern void __gcov_dump(void);
+extern void __gcov_reset(void);
+#endif
+
 void dbg_bt(Process* p, Eterm* sp);
 void dbg_where(ErtsCodePtr addr, Eterm x0, Eterm* reg);
 
@@ -530,6 +536,61 @@ erts_debug_interpreter_size_0(BIF_ALIST_0)
     return erts_make_integer(high - low, BIF_P);
 #else
     return make_small(0);
+#endif
+}
+
+/*
+ * Reset or dump gcov coverage counters for the emulator itself.
+ *
+ * Only supported in gcov builds of the emulator; in all other builds
+ * the atom 'not_supported' is returned.
+ */
+BIF_RETTYPE
+erts_debug_coverage_1(BIF_ALIST_1)
+{
+#ifdef ERTS_GCOV
+    if (BIF_ARG_1 == am_reset) {
+        /*
+         * The libgcov counter manipulation functions are not thread
+         * safe, so we block the system while using them.
+         */
+        erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_thr_progress_block();
+        __gcov_reset();
+        erts_thr_progress_unblock();
+        erts_proc_lock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        BIF_RET(am_ok);
+    }
+    else if (is_tuple_arity(BIF_ARG_1, 2)) {
+        Eterm *tp = tuple_val(BIF_ARG_1);
+        char *path;
+
+        if (tp[1] != am_dump) {
+            BIF_ERROR(BIF_P, BADARG);
+        }
+        path = erts_convert_filename_to_native(tp[2], NULL, 0,
+                                               ERTS_ALC_T_TMP, 0, 0, NULL);
+        if (path == NULL) {
+            BIF_ERROR(BIF_P, BADARG);
+        }
+        erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_thr_progress_block();
+        /*
+         * libgcov reads the real environment of the process, so we
+         * must use setenv() here; os:putenv() only updates the
+         * emulated environment kept by ERTS.
+         */
+        setenv("GCOV_PREFIX", path, 1);
+        setenv("GCOV_PREFIX_STRIP", "100", 1);
+        __gcov_dump();
+        erts_thr_progress_unblock();
+        erts_proc_lock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_free(ERTS_ALC_T_TMP, path);
+        BIF_RET(am_ok);
+    }
+    BIF_ERROR(BIF_P, BADARG);
+#else
+    BIF_RET(am_not_supported);
 #endif
 }
 

--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -56,6 +56,13 @@ extern void __gcov_dump(void);
 extern void __gcov_reset(void);
 #endif
 
+#ifdef ERTS_CLANG_COVERAGE
+/* Provided by the clang/LLVM profile runtime (compiler-rt). */
+extern void __llvm_profile_reset_counters(void);
+extern int __llvm_profile_write_file(void);
+extern void __llvm_profile_set_filename(const char *);
+#endif
+
 void dbg_bt(Process* p, Eterm* sp);
 void dbg_where(ErtsCodePtr addr, Eterm x0, Eterm* reg);
 
@@ -540,15 +547,16 @@ erts_debug_interpreter_size_0(BIF_ALIST_0)
 }
 
 /*
- * Reset or dump gcov coverage counters for the emulator itself.
+ * Reset or dump native coverage counters for the emulator itself.
  *
- * Only supported in gcov builds of the emulator; in all other builds
- * the atom 'not_supported' is returned.
+ * Supported in gcov builds (libgcov) and in clang source-based coverage
+ * builds (the LLVM profile runtime); in all other builds the atom
+ * 'not_supported' is returned.
  */
 BIF_RETTYPE
 erts_debug_coverage_1(BIF_ALIST_1)
 {
-#ifdef ERTS_GCOV
+#if defined(ERTS_GCOV)
     if (BIF_ARG_1 == am_reset) {
         /*
          * The libgcov counter manipulation functions are not thread
@@ -585,6 +593,51 @@ erts_debug_coverage_1(BIF_ALIST_1)
         __gcov_dump();
         erts_thr_progress_unblock();
         erts_proc_lock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_free(ERTS_ALC_T_TMP, path);
+        BIF_RET(am_ok);
+    }
+    BIF_ERROR(BIF_P, BADARG);
+#elif defined(ERTS_CLANG_COVERAGE)
+    if (BIF_ARG_1 == am_reset) {
+        /* Match the gcov path: block the system while touching counters. */
+        erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_thr_progress_block();
+        __llvm_profile_reset_counters();
+        erts_thr_progress_unblock();
+        erts_proc_lock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        BIF_RET(am_ok);
+    }
+    else if (is_tuple_arity(BIF_ARG_1, 2)) {
+        Eterm *tp = tuple_val(BIF_ARG_1);
+        char *path, *file;
+        size_t plen;
+        static const char suffix[] = "/erl_%p.profraw";
+
+        if (tp[1] != am_dump) {
+            BIF_ERROR(BIF_P, BADARG);
+        }
+        path = erts_convert_filename_to_native(tp[2], NULL, 0,
+                                               ERTS_ALC_T_TMP, 0, 0, NULL);
+        if (path == NULL) {
+            BIF_ERROR(BIF_P, BADARG);
+        }
+        /*
+         * __llvm_profile_write_file() writes to the currently configured
+         * filename; direct it into the requested directory. The literal
+         * "%p" is expanded by the profile runtime to the OS pid, so
+         * concurrently dumping peer nodes do not clobber each other.
+         */
+        plen = sys_strlen(path);
+        file = erts_alloc(ERTS_ALC_T_TMP, plen + sizeof(suffix));
+        sys_memcpy(file, path, plen);
+        sys_memcpy(file + plen, suffix, sizeof(suffix));
+        erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_thr_progress_block();
+        __llvm_profile_set_filename(file);
+        (void) __llvm_profile_write_file();
+        erts_thr_progress_unblock();
+        erts_proc_lock(BIF_P, ERTS_PROC_LOCK_MAIN);
+        erts_free(ERTS_ALC_T_TMP, file);
         erts_free(ERTS_ALC_T_TMP, path);
         BIF_RET(am_ok);
     }

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -859,3 +859,9 @@ bif records:is_exported/1
 bif records:create/4
 bif records:update/4
 bif records:get_definition/2
+
+#
+# Coverage support for the emulator itself (gcov builds).
+#
+
+bif erts_debug:coverage/1

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2803,6 +2803,9 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 #elif defined(ERTS_GCOV)
 	ERTS_DECL_AM(gcov);
 	BIF_RET(AM_gcov);
+#elif defined(ERTS_CLANG_COVERAGE)
+	ERTS_DECL_AM(clangcov);
+	BIF_RET(AM_clangcov);
 #elif defined(VALGRIND)
 	ERTS_DECL_AM(valgrind);
 	BIF_RET(AM_valgrind);

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -132,6 +132,8 @@ typedef struct driver_data {
 #define ERL_BUILD_TYPE_MARKER ".debug"
 #elif defined(VALGRIND)
 #define ERL_BUILD_TYPE_MARKER ".valgrind"
+#elif defined(ERTS_CLANG_COVERAGE)
+#define ERL_BUILD_TYPE_MARKER ".clangcov"
 #else /* opt */
 #define ERL_BUILD_TYPE_MARKER
 #endif

--- a/erts/lib_src/Makefile.in
+++ b/erts/lib_src/Makefile.in
@@ -65,6 +65,11 @@ CFLAGS=@DEBUG_CFLAGS@ -DGCOV -fprofile-arcs -ftest-coverage -O0
 TYPE_SUFFIX=.gcov
 PRE_LD=
 else
+ifeq ($(TYPE),clangcov)
+CFLAGS:=$(CFLAGS) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
+TYPE_SUFFIX=.clangcov
+PRE_LD=
+else
 ifeq ($(TYPE),valgrind)
 CFLAGS=@DEBUG_CFLAGS@ -DVALGRIND
 TYPE_SUFFIX=.valgrind
@@ -105,6 +110,7 @@ OMIT_FP=true
 endif
 TYPE_SUFFIX=
 PRE_LD=
+endif
 endif
 endif
 endif

--- a/erts/lib_src/Makefile.in
+++ b/erts/lib_src/Makefile.in
@@ -67,8 +67,9 @@ PRE_LD=
 else
 ifeq ($(TYPE),clangcov)
 # Built with clang: drop GCC-only flags a gcc-configured @CFLAGS@ may
-# carry (-Wtrampolines) and blanket -Werror (keeps -Werror=<name>).
-CFLAGS:=$(filter-out -Werror -Wtrampolines,$(CFLAGS)) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
+# carry (-Wtrampolines), the blanket -Werror (keeps -Werror=<name>), and
+# UBSan (-fsanitize=..., whose runtime is not linked into a coverage build).
+CFLAGS:=$(filter-out -Werror -Wtrampolines -fsanitize=signed-integer-overflow,$(CFLAGS)) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
 TYPE_SUFFIX=.clangcov
 PRE_LD=
 else

--- a/erts/lib_src/Makefile.in
+++ b/erts/lib_src/Makefile.in
@@ -66,7 +66,9 @@ TYPE_SUFFIX=.gcov
 PRE_LD=
 else
 ifeq ($(TYPE),clangcov)
-CFLAGS:=$(CFLAGS) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
+# Built with clang: drop GCC-only flags a gcc-configured @CFLAGS@ may
+# carry (-Wtrampolines) and blanket -Werror (keeps -Werror=<name>).
+CFLAGS:=$(filter-out -Werror -Wtrampolines,$(CFLAGS)) -DERTS_CLANG_COVERAGE -fprofile-instr-generate -fcoverage-mapping
 TYPE_SUFFIX=.clangcov
 PRE_LD=
 else

--- a/lib/common_test/src/Makefile
+++ b/lib/common_test/src/Makefile
@@ -77,6 +77,7 @@ MODULES= \
 	cte_track\
 	cth_log_redirect\
 	cth_surefire \
+	cth_coverage \
 	ct_netconfc \
 	ct_conn_log_h \
 	cth_conn_log \
@@ -179,5 +180,6 @@ release_docs_spec: docs
 $(EBIN)/cth_log_redirect.beam: $(EBIN)/ct_hooks.beam
 $(EBIN)/cth_conn_log.beam: $(EBIN)/ct_hooks.beam
 $(EBIN)/cth_surefire.beam: $(EBIN)/ct_hooks.beam
+$(EBIN)/cth_coverage.beam: $(EBIN)/ct_hooks.beam
 
 include $(ERL_TOP)/make/dep.mk

--- a/lib/common_test/src/Makefile
+++ b/lib/common_test/src/Makefile
@@ -59,6 +59,7 @@ MODULES= \
 	ct_telnet \
 	ct_util \
 	ct_cover \
+	ct_cover_to_lcov \
 	ct_doctest \
 	ct_testspec \
 	ct_event \

--- a/lib/common_test/src/Makefile
+++ b/lib/common_test/src/Makefile
@@ -59,6 +59,7 @@ MODULES= \
 	ct_telnet \
 	ct_util \
 	ct_cover \
+	ct_cover_to_html \
 	ct_cover_to_lcov \
 	ct_doctest \
 	ct_testspec \

--- a/lib/common_test/src/common_test.app.src
+++ b/lib/common_test/src/common_test.app.src
@@ -23,6 +23,7 @@
  [{description, "The OTP Common Test application"},
   {vsn, "%VSN%"},
   {modules, [ct_cover,
+	     ct_cover_to_html,
 	     ct_cover_to_lcov,
 	     ct,
 	     ct_doctest,

--- a/lib/common_test/src/common_test.app.src
+++ b/lib/common_test/src/common_test.app.src
@@ -23,6 +23,7 @@
  [{description, "The OTP Common Test application"},
   {vsn, "%VSN%"},
   {modules, [ct_cover,
+	     ct_cover_to_lcov,
 	     ct,
 	     ct_doctest,
              ct_default_gl,

--- a/lib/common_test/src/common_test.app.src
+++ b/lib/common_test/src/common_test.app.src
@@ -61,6 +61,7 @@
              cth_log_redirect,
 	     cth_conn_log,
              cth_surefire,
+             cth_coverage,
 	     erl2html2,
 	     test_server_ctrl,
 	     test_server,

--- a/lib/common_test/src/ct_cover_to_html.erl
+++ b/lib/common_test/src/ct_cover_to_html.erl
@@ -1,0 +1,448 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(ct_cover_to_html).
+-moduledoc false.
+
+%%% Convert the per-testcase coverage artifacts written by cth_coverage
+%%% into an interactive HTML *attribution* report: for every instrumented
+%%% source line, which test cases executed it.
+%%%
+%%% Unlike the merged LCOV output produced by ct_cover_to_lcov, this
+%%% report keeps the per-testcase dimension. Each input file
+%%%
+%%%    <Suite>.<Case>.coverdata = term_to_binary([{Module, [{Line, Count}]}])
+%%%
+%%% (as written by cth_coverage, with only executed lines present) is
+%%% attributed to the test case named by its file basename. The report
+%%% therefore answers "which test cases cover this line", aggregated
+%%% across every test job that touched the module -- including test
+%%% cases from other applications, which is what makes it a cross-app
+%%% coverage view.
+%%%
+%%% The line manifest written by cth_coverage
+%%% (<dir>/coverage.manifest = term_to_binary([{Module, [Line]}]) with
+%%% ALL instrumented lines) is used, when supplied via {manifest, File},
+%%% to mark instrumented-but-unexecuted lines (the coverage gaps) in red.
+%%%
+%%% One HTML page is written per module plus an index. Source is located
+%%% best-effort from the loaded module's compile info; when it cannot be
+%%% found the page still shows the attribution, without the source text.
+
+-export([convert/2, convert/3, main/1]).
+
+%% A single hot line can be reached by very many test cases; cap how many
+%% names are embedded per line to keep the report a bounded size. The true
+%% count is always shown; the surplus is reported as "+N more".
+-define(DEFAULT_MAX_TESTS_PER_LINE, 200).
+-define(DEFAULT_TITLE, "Erlang/OTP coverage attribution").
+
+-doc """
+Read all `InFiles` (one per test case) and write an interactive HTML
+attribution report to `OutDir`.
+
+Unreadable or malformed input files are skipped with a warning on
+standard error.
+""".
+-spec convert(InFiles, OutDir) -> ok | {error, term()} when
+      InFiles :: [file:filename()],
+      OutDir :: file:filename().
+convert(InFiles, OutDir) ->
+    convert(InFiles, OutDir, []).
+
+-doc """
+As `convert/2`, with options.
+
+* `{manifest, ManifestFile}` names the line manifest written by
+  cth_coverage; its instrumented lines that no test case executed are
+  rendered as un-hit. An unreadable or malformed manifest is an error.
+* `{max_tests_per_line, N}` caps how many test-case names are embedded
+  per line (200 by default); the true count is always shown.
+* `{title, String}` sets the report title.
+* `{source_map, #{module() => filename()}}` overrides source-file
+  resolution for the given modules (otherwise the source is located from
+  the module's compile info / code path).
+""".
+-spec convert(InFiles, OutDir, Opts) -> ok | {error, term()} when
+      InFiles :: [file:filename()],
+      OutDir :: file:filename(),
+      Opts :: [Opt],
+      Opt :: {manifest, file:filename()}
+           | {max_tests_per_line, pos_integer()}
+           | {title, string()}
+           | {source_map, #{module() => file:filename()}}.
+convert(InFiles, OutDir, Opts) when is_list(InFiles), is_list(Opts) ->
+    case load_manifest(proplists:get_value(manifest, Opts)) of
+        {ok, Manifest} ->
+            Cfg = #{max => proplists:get_value(max_tests_per_line, Opts,
+                                               ?DEFAULT_MAX_TESTS_PER_LINE),
+                    title => proplists:get_value(title, Opts, ?DEFAULT_TITLE),
+                    smap => proplists:get_value(source_map, Opts, #{})},
+            Attr = lists:foldl(fun attribute_file/2, #{}, InFiles),
+            write_report(OutDir, Attr, Manifest, Cfg);
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc """
+Escript entry point.
+
+Usage: `ct_cover_to_html [--manifest <file>] [--max-per-line <n>]
+[--title <t>] <out-dir> (<coverdata-dir> | <in1.coverdata> ...)`
+""".
+-spec main(Args :: [string()]) -> ok | no_return().
+main(Args) ->
+    main(Args, []).
+
+main(["--manifest", F | Rest], Opts) ->
+    main(Rest, [{manifest, F} | Opts]);
+main(["--max-per-line", N | Rest], Opts) ->
+    main(Rest, [{max_tests_per_line, list_to_integer(N)} | Opts]);
+main(["--title", T | Rest], Opts) ->
+    main(Rest, [{title, T} | Opts]);
+main([OutDir, MaybeDir], Opts) ->
+    InFiles =
+        case filelib:is_dir(MaybeDir) of
+            true -> filelib:wildcard(filename:join(MaybeDir, "*.coverdata"));
+            false -> [MaybeDir]
+        end,
+    run(InFiles, OutDir, Opts);
+main([OutDir | InFiles], Opts) when InFiles =/= [] ->
+    run(InFiles, OutDir, Opts);
+main(_, _Opts) ->
+    io:format(standard_error,
+              "usage: ct_cover_to_html [--manifest <file>] [--max-per-line <n>] "
+              "[--title <t>] <out-dir> (<coverdata-dir> | <in.coverdata> ...)~n",
+              []),
+    erlang:halt(1).
+
+run([], _OutDir, _Opts) ->
+    io:format(standard_error,
+              "ct_cover_to_html: error: no input .coverdata files~n", []),
+    erlang:halt(1);
+run(InFiles, OutDir, Opts) ->
+    case convert(InFiles, OutDir, Opts) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            io:format(standard_error,
+                      "ct_cover_to_html: error: ~tp~n", [Reason]),
+            erlang:halt(1)
+    end.
+
+%%%-----------------------------------------------------------------
+%%% Reading and attributing
+
+%% Attr :: #{Module => #{Line => [TestId]}}
+attribute_file(File, Acc) ->
+    Tid = filename:basename(File, ".coverdata"),
+    case file:read_file(File) of
+        {ok, Bin} ->
+            try binary_to_term(Bin) of
+                Data when is_list(Data) ->
+                    try lists:foldl(fun(E, A) -> attribute_module(Tid, E, A) end,
+                                    Acc, Data)
+                    catch _:_ -> warn(File, malformed_coverdata), Acc
+                    end;
+                _ ->
+                    warn(File, malformed_coverdata), Acc
+            catch error:badarg ->
+                    warn(File, not_external_term_format), Acc
+            end;
+        {error, Reason} ->
+            warn(File, Reason), Acc
+    end.
+
+attribute_module(Tid, {Module, Lines}, Acc)
+  when is_atom(Module), is_list(Lines) ->
+    ModMap = lists:foldl(fun(L, A) -> attribute_line(Tid, L, A) end,
+                         maps:get(Module, Acc, #{}), Lines),
+    Acc#{Module => ModMap}.
+
+attribute_line(Tid, {Line, Count}, ModMap)
+  when is_integer(Line), Line > 0, is_integer(Count), Count > 0 ->
+    maps:update_with(Line, fun(Ts) -> [Tid | Ts] end, [Tid], ModMap);
+attribute_line(_Tid, {Line, _Count}, ModMap) when is_integer(Line) ->
+    ModMap.
+
+warn(File, Reason) ->
+    io:format(standard_error,
+              "ct_cover_to_html: warning: skipping ~ts: ~tp~n",
+              [File, Reason]).
+
+%%%-----------------------------------------------------------------
+%%% Line manifest (all instrumented lines, executed or not)
+
+%% Reused shape from ct_cover_to_lcov: #{Module => [Line]} sorted/unique.
+load_manifest(undefined) ->
+    {ok, #{}};
+load_manifest(File) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            try binary_to_term(Bin) of
+                Data when is_list(Data) ->
+                    try {ok, lists:foldl(fun manifest_module/2, #{}, Data)}
+                    catch _:_ -> {error, {manifest, File, malformed_manifest}}
+                    end;
+                _ ->
+                    {error, {manifest, File, malformed_manifest}}
+            catch error:badarg ->
+                    {error, {manifest, File, not_external_term_format}}
+            end;
+        {error, Reason} ->
+            {error, {manifest, File, Reason}}
+    end.
+
+manifest_module({Module, Lines}, Acc) when is_atom(Module), is_list(Lines) ->
+    Good = lists:usort([L || L <- Lines, is_integer(L), L > 0]),
+    maps:update_with(Module, fun(Ls) -> lists:umerge(Good, Ls) end, Good, Acc).
+
+%%%-----------------------------------------------------------------
+%%% Report
+
+write_report(OutDir, Attr, Manifest, Cfg) ->
+    ok = filelib:ensure_dir(filename:join(OutDir, "index.html")),
+    Mods = lists:usort(maps:keys(Attr) ++ maps:keys(Manifest)),
+    _ = [render_module(M, OutDir, maps:get(M, Attr, #{}),
+                       maps:get(M, Manifest, []), Cfg) || M <- Mods],
+    render_index(OutDir, Mods, Attr, Manifest, all_tests(Attr), Cfg),
+    ok.
+
+all_tests(Attr) ->
+    lists:usort(
+      maps:fold(fun(_M, LM, Acc) ->
+                        maps:fold(fun(_L, Ts, A) -> Ts ++ A end, Acc, LM)
+                end, [], Attr)).
+
+stats(AttrM, ManL) ->
+    Instr = length(ManL),
+    Hit = length([1 || L <- ManL, maps:is_key(L, AttrM)]),
+    %% Lines hit but absent from the manifest (e.g. no manifest supplied)
+    %% still count towards both totals.
+    Extra = length([1 || L <- maps:keys(AttrM), not lists:member(L, ManL)]),
+    {Hit + Extra, Instr + Extra}.
+
+pct(_, 0) -> 100.0;
+pct(H, I) -> 100.0 * H / I.
+
+%%%---------------- index ----------------
+render_index(OutDir, Mods, Attr, Manifest, Tests, #{title := Title}) ->
+    Rows = [index_row(M, maps:get(M, Attr, #{}), maps:get(M, Manifest, []))
+            || M <- Mods],
+    {TH, TI} = lists:foldl(
+                 fun(M, {H0, I0}) ->
+                         {H, I} = stats(maps:get(M, Attr, #{}),
+                                        maps:get(M, Manifest, [])),
+                         {H0 + H, I0 + I}
+                 end, {0, 0}, Mods),
+    Html =
+        ["<!doctype html><meta charset=utf-8><title>", esc(Title), "</title>",
+         css(),
+         "<h1>", esc(Title), "</h1>",
+         io_lib:format("<p class=sub>~w modules &middot; ~w test cases &middot; "
+                       "overall <b>~.1f%</b> (~w/~w lines)</p>",
+                       [length(Mods), length(Tests), pct(TH, TI), TH, TI]),
+         "<table class=idx><thead><tr><th>Module</th><th>Lines</th>"
+         "<th>Coverage</th><th></th></tr></thead><tbody>", Rows,
+         "</tbody></table>"],
+    write_utf8(filename:join(OutDir, "index.html"), Html).
+
+index_row(M, AttrM, ManL) ->
+    {H, I} = stats(AttrM, ManL),
+    P = pct(H, I),
+    io_lib:format(
+      "<tr><td><a href=\"~ts.html\">~ts</a></td>"
+      "<td class=num>~w/~w</td><td class=num>~.1f%</td>"
+      "<td class=barcell><div class=bar><div class=fill "
+      "style=\"width:~.1f%;background:~ts\"></div></div></td></tr>",
+      [M, M, H, I, P, P, barcolor(P)]).
+
+barcolor(P) when P >= 75 -> "#4caf50";
+barcolor(P) when P >= 40 -> "#ffb300";
+barcolor(_) -> "#e53935".
+
+%%%---------------- per-module page ----------------
+render_module(M, OutDir, AttrM, ManL, #{max := Max, smap := SMap}) ->
+    ManSet = maps:from_keys(ManL, true),
+    Lines = source_lines(M, SMap),
+    {H, I} = stats(AttrM, ManL),
+    Body = [render_line(N, Text, AttrM, ManSet)
+            || {N, Text} <- lists:enumerate(Lines)],
+    Cov = cov_json(AttrM, Max),
+    Html =
+        ["<!doctype html><meta charset=utf-8><title>", atom_to_list(M),
+         " coverage</title>", css(),
+         io_lib:format("<div class=top><a href=\"index.html\">&larr; all modules</a>"
+                       " &nbsp; <b>~ts</b> &nbsp; <span class=sub>~.1f% (~w/~w lines)"
+                       "</span></div>", [M, pct(H, I), H, I]),
+         "<div class=legend><span class=k><i class='sw hit'></i>covered</span>"
+         "<span class=k><i class='sw miss'></i>instrumented, not hit</span>"
+         "<span class=k>click a covered line &rarr; its test cases; "
+         "type below &rarr; highlight a test case's lines</span></div>",
+         "<div class=wrap><div class=code><table>", Body, "</table></div>",
+         "<div class=panel><div class=pctl>highlight test case: "
+         "<input id=filter type=text placeholder='substring' "
+         "oninput=\"filterTest(this.value)\"></div>"
+         "<div id=panel class=pbody>Click a "
+         "<span class=hit style='padding:0 4px'>covered</span> line.</div>"
+         "</div></div>",
+         "<script>var COV=", Cov, ";", js(), "</script>"],
+    write_utf8(filename:join(OutDir, atom_to_list(M) ++ ".html"), Html).
+
+render_line(N, Text, AttrM, ManSet) ->
+    Esc = esc(Text),
+    case maps:get(N, AttrM, undefined) of
+        undefined ->
+            Cls = case maps:is_key(N, ManSet) of true -> "miss"; false -> "none" end,
+            io_lib:format("<tr id=L~w class=~ts><td class=ln>~w</td>"
+                          "<td class=cnt></td><td class=src>~ts</td></tr>",
+                          [N, Cls, N, Esc]);
+        Tids ->
+            K = length(lists:usort(Tids)),
+            io_lib:format("<tr id=L~w class=hit onclick=\"showTests(~w)\">"
+                          "<td class=ln>~w</td><td class=cnt title='~w test cases'>~w</td>"
+                          "<td class=src>~ts</td></tr>", [N, N, N, K, K, Esc])
+    end.
+
+%% COV[Line] = {n: true unique count, t: [up to Max sorted test ids]}
+cov_json(AttrM, Max) ->
+    Entries =
+        [begin
+             U = lists:usort(Ts),
+             T = lists:sublist(U, Max),
+             io_lib:format("\"~w\":{\"n\":~w,\"t\":[~ts]}",
+                           [L, length(U),
+                            lists:join(",", [json_str(X) || X <- T])])
+         end || {L, Ts} <- lists:sort(maps:to_list(AttrM))],
+    ["{", lists:join(",", Entries), "}"].
+
+%%%---------------- source ----------------
+source_lines(M, SMap) ->
+    case source_file(M, SMap) of
+        undefined ->
+            ["%% (source not available for " ++ atom_to_list(M) ++ ")"];
+        Path ->
+            case file:read_file(Path) of
+                {ok, Bin} ->
+                    string:split(unicode:characters_to_list(Bin), "\n", all);
+                _ ->
+                    ["%% (source not available for " ++ atom_to_list(M) ++ ")"]
+            end
+    end.
+
+%% Best-effort source resolution, mirroring ct_cover_to_lcov, with an
+%% explicit source_map override taking precedence.
+source_file(Module, SMap) ->
+    case maps:get(Module, SMap, undefined) of
+        undefined -> source_from_info(Module);
+        Path -> Path
+    end.
+
+source_from_info(Module) ->
+    Source = try Module:module_info(compile) of
+                 Info when is_list(Info) -> proplists:get_value(source, Info);
+                 _ -> undefined
+             catch _:_ -> undefined
+             end,
+    case Source of
+        [_ | _] ->
+            Abs = filename:absname(Source),
+            case filelib:is_regular(Abs) of
+                true -> Abs;
+                false -> source_from_beam(Module)
+            end;
+        _ ->
+            source_from_beam(Module)
+    end.
+
+source_from_beam(Module) ->
+    try code:which(Module) of
+        Beam when is_list(Beam), Beam =/= [] ->
+            AppDir = filename:dirname(filename:dirname(Beam)),
+            Src = filename:join([AppDir, "src", atom_to_list(Module) ++ ".erl"]),
+            case filelib:is_regular(Src) of
+                true -> filename:absname(Src);
+                false -> undefined
+            end;
+        _ ->
+            undefined
+    catch _:_ ->
+            undefined
+    end.
+
+%%%---------------- helpers ----------------
+write_utf8(File, Iodata) ->
+    file:write_file(File, unicode:characters_to_binary(Iodata)).
+
+esc(Text) ->
+    lists:map(fun($<) -> "&lt;";
+                 ($>) -> "&gt;";
+                 ($&) -> "&amp;";
+                 (C) -> C
+              end, lists:flatten(Text)).
+
+json_str(S) ->
+    ["\"", lists:map(fun($") -> "\\\"";
+                        ($\\) -> "\\\\";
+                        (C) -> C
+                     end, lists:flatten(S)), "\""].
+
+%%%---------------- assets ----------------
+css() ->
+    "<style>"
+    "body{font:13px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;margin:0;color:#222;background:#fafafa}"
+    "h1{font-size:20px;margin:16px 20px 4px}.sub{color:#777}"
+    ".top{padding:10px 20px;background:#fff;border-bottom:1px solid #ddd;position:sticky;top:0;z-index:2}"
+    ".top a{color:#1565c0;text-decoration:none}"
+    ".legend{padding:6px 20px;color:#666;background:#f2f2f2;border-bottom:1px solid #e0e0e0}"
+    ".legend .k{margin-right:18px}.sw{display:inline-block;width:11px;height:11px;vertical-align:-1px;margin-right:5px;border-radius:2px}"
+    ".sw.hit{background:#c8e6c9}.sw.miss{background:#ffcdd2}"
+    ".wrap{display:flex;align-items:flex-start}"
+    ".code{flex:1;overflow-x:auto;background:#fff}"
+    ".code table{border-collapse:collapse;width:100%;font:12px/1.5 SFMono-Regular,Menlo,Consolas,monospace}"
+    ".code td{padding:0 8px;white-space:pre}"
+    ".ln{text-align:right;color:#999;background:#f6f6f6;user-select:none;border-right:1px solid #eee}"
+    ".cnt{text-align:right;color:#2e7d32;background:#f6f6f6;user-select:none;min-width:20px}"
+    "tr.hit .src{background:#e8f5e9}tr.hit{cursor:pointer}tr.hit:hover .src{background:#d3ecd4}"
+    "tr.miss .src{background:#ffebee}"
+    "tr.sel .src{background:#fff59d!important}tr.hi .src{background:#bbdefb!important}"
+    ".panel{width:320px;position:sticky;top:52px;align-self:flex-start;background:#fff;border-left:1px solid #ddd;height:calc(100vh - 52px);overflow:auto}"
+    ".pctl{padding:10px;border-bottom:1px solid #eee;color:#555}"
+    ".pctl input{width:96%;padding:3px}"
+    ".pbody{padding:12px}.pbody ul{margin:8px 0 0;padding-left:18px}.pbody li{margin:2px 0;word-break:break-all}"
+    ".idx{border-collapse:collapse;margin:12px 20px}.idx th,.idx td{padding:4px 12px;border-bottom:1px solid #eee;text-align:left}"
+    ".idx .num{text-align:right;font-variant-numeric:tabular-nums}.idx a{color:#1565c0;text-decoration:none}"
+    ".bar{width:160px;height:10px;background:#eee;border-radius:5px;overflow:hidden}.fill{height:100%}"
+    "</style>".
+
+js() ->
+    "function clr(c){var e=document.getElementsByClassName(c);"
+    "while(e.length)e[0].classList.remove(c);}"
+    "function showTests(l){clr('sel');var r=document.getElementById('L'+l);"
+    "if(r)r.classList.add('sel');var o=COV[l]||{n:0,t:[]};var t=o.t.slice().sort();"
+    "var more=o.n-t.length;"
+    "var h='<b>Line '+l+'</b> covered by '+o.n+' test case(s):<ul>'+"
+    "t.map(function(x){return '<li>'+x+'</li>';}).join('')+'</ul>'+"
+    "(more>0?('<p class=sub>+'+more+' more (raise --max-per-line to list all)</p>'):'');"
+    "document.getElementById('panel').innerHTML=h;}"
+    "function filterTest(s){clr('hi');if(!s)return;"
+    "for(var l in COV){if(COV[l].t.some(function(x){return x.indexOf(s)>=0;})){"
+    "var e=document.getElementById('L'+l);if(e)e.classList.add('hi');}}}".

--- a/lib/common_test/src/ct_cover_to_html.erl
+++ b/lib/common_test/src/ct_cover_to_html.erl
@@ -232,13 +232,13 @@ all_tests(Attr) ->
                         maps:fold(fun(_L, Ts, A) -> Ts ++ A end, Acc, LM)
                 end, [], Attr)).
 
+%% Hit = every line some test case executed (a hit line is, by definition,
+%% instrumented). Instr = the instrumented lines, i.e. the manifest unioned
+%% with the hit lines, so the ratio is correct even with no manifest.
 stats(AttrM, ManL) ->
-    Instr = length(ManL),
-    Hit = length([1 || L <- ManL, maps:is_key(L, AttrM)]),
-    %% Lines hit but absent from the manifest (e.g. no manifest supplied)
-    %% still count towards both totals.
-    Extra = length([1 || L <- maps:keys(AttrM), not lists:member(L, ManL)]),
-    {Hit + Extra, Instr + Extra}.
+    Union = lists:foldl(fun(L, A) -> A#{L => true} end,
+                        maps:from_keys(ManL, true), maps:keys(AttrM)),
+    {maps:size(AttrM), maps:size(Union)}.
 
 pct(_, 0) -> 100.0;
 pct(H, I) -> 100.0 * H / I.

--- a/lib/common_test/src/ct_cover_to_lcov.erl
+++ b/lib/common_test/src/ct_cover_to_lcov.erl
@@ -34,18 +34,18 @@
 %%% merged by summing counts per {Module, Line} before the LCOV
 %%% output is written.
 %%%
-%%% TODO: the sparse coverdata written by cth_coverage only contains
-%%%       EXECUTED lines, so this converter cannot emit DA records
-%%%       for instrumented-but-unexecuted lines. As a consequence LF
-%%%       equals the number of executed lines and every file appears
-%%%       fully covered (LH == LF) in LCOV consumers. To fix, feed
-%%%       this tool the full instrumented-line set per module: a
-%%%       single code:get_coverage(line, Module) call returns ALL
-%%%       instrumented lines including those with count 0 (which
-%%%       cth_coverage currently filters out for sparsity), and emit
-%%%       DA:<line>,0 for the un-hit ones.
+%%% The sparse coverdata only contains EXECUTED lines. To also emit
+%%% DA records for instrumented-but-unexecuted lines, supply the line
+%%% manifest written by cth_coverage at the end of the run
+%%% (<dir>/coverage.manifest, term_to_binary([{Module, [Line]}]) with
+%%% ALL instrumented lines) via the {manifest, File} option of
+%%% convert/3 or the --manifest escript argument. Un-hit manifest
+%%% lines are then emitted as DA:<line>,0, making LF (instrumented
+%%% lines) and LH (hit lines) meaningful. Without a manifest only
+%%% executed lines are emitted, so every file appears fully covered
+%%% (LH == LF) in LCOV consumers.
 
--export([convert/2, main/1]).
+-export([convert/2, convert/3, main/1]).
 
 -doc """
 Read all `InFiles`, merge their per-line execution counts, and write
@@ -57,20 +57,50 @@ standard error.
 -spec convert(InFiles, OutFile) -> ok | {error, term()} when
       InFiles :: [file:filename()],
       OutFile :: file:filename().
-convert(InFiles, OutFile) when is_list(InFiles) ->
-    Merged = lists:foldl(fun merge_file/2, #{}, InFiles),
-    write_lcov(Merged, OutFile).
+convert(InFiles, OutFile) ->
+    convert(InFiles, OutFile, []).
+
+-doc """
+As `convert/2`, with options.
+
+`{manifest, ManifestFile}` names a line manifest written by
+cth_coverage (`term_to_binary([{Module, [Line]}])` with all
+instrumented lines). Manifest lines not present in the merged
+coverdata are emitted with count 0, so instrumented-but-unexecuted
+lines show up as un-hit. An unreadable or malformed manifest is an
+error (not skipped): silently emitting all-covered output would
+defeat its purpose.
+""".
+-spec convert(InFiles, OutFile, Opts) -> ok | {error, term()} when
+      InFiles :: [file:filename()],
+      OutFile :: file:filename(),
+      Opts :: [{manifest, file:filename()}].
+convert(InFiles, OutFile, Opts) when is_list(InFiles), is_list(Opts) ->
+    case load_manifest(proplists:get_value(manifest, Opts)) of
+        {ok, Manifest} ->
+            Merged = lists:foldl(fun merge_file/2, #{}, InFiles),
+            write_lcov(apply_manifest(Manifest, Merged), OutFile);
+        {error, _} = Error ->
+            Error
+    end.
 
 -doc """
 Escript entry point.
 
-Usage: `ct_cover_to_lcov <out.info> <in1.coverdata> ...`
+Usage: `ct_cover_to_lcov [--manifest <file>] <out.info> <in1.coverdata> ...`
 
 If a single input argument is given and it is a directory, all
-`*.coverdata` files in it are converted.
+`*.coverdata` files in it are converted. With `--manifest`, the line
+manifest written by cth_coverage (`<dir>/coverage.manifest`) is used
+to emit un-hit instrumented lines with count 0.
 """.
 -spec main(Args :: [string()]) -> ok | no_return().
-main([OutFile, MaybeDir]) ->
+main(["--manifest", ManifestFile | Args]) ->
+    main(Args, [{manifest, ManifestFile}]);
+main(Args) ->
+    main(Args, []).
+
+main([OutFile, MaybeDir], Opts) ->
     InFiles =
         case filelib:is_dir(MaybeDir) of
             true ->
@@ -78,21 +108,23 @@ main([OutFile, MaybeDir]) ->
             false ->
                 [MaybeDir]
         end,
-    run(InFiles, OutFile);
-main([OutFile | InFiles]) when InFiles =/= [] ->
-    run(InFiles, OutFile);
-main(_) ->
+    run(InFiles, OutFile, Opts);
+main([OutFile | InFiles], Opts) when InFiles =/= [] ->
+    run(InFiles, OutFile, Opts);
+main(_, _Opts) ->
     io:format(standard_error,
-              "usage: ct_cover_to_lcov <out.info> <in1.coverdata> ...~n"
-              "       ct_cover_to_lcov <out.info> <coverdata-dir>~n", []),
+              "usage: ct_cover_to_lcov [--manifest <file>] "
+              "<out.info> <in1.coverdata> ...~n"
+              "       ct_cover_to_lcov [--manifest <file>] "
+              "<out.info> <coverdata-dir>~n", []),
     erlang:halt(1).
 
-run([], _OutFile) ->
+run([], _OutFile, _Opts) ->
     io:format(standard_error,
               "ct_cover_to_lcov: error: no input .coverdata files~n", []),
     erlang:halt(1);
-run(InFiles, OutFile) ->
-    case convert(InFiles, OutFile) of
+run(InFiles, OutFile, Opts) ->
+    case convert(InFiles, OutFile, Opts) of
         ok ->
             ok;
         {error, Reason} ->
@@ -142,6 +174,51 @@ warn(File, Reason) ->
     io:format(standard_error,
               "ct_cover_to_lcov: warning: skipping ~ts: ~tp~n",
               [File, Reason]).
+
+%%%-----------------------------------------------------------------
+%%% Line manifest (all instrumented lines, executed or not)
+
+%% Load the manifest into #{Module => [Line]} (lines sorted, unique).
+load_manifest(undefined) ->
+    {ok, #{}};
+load_manifest(File) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            try binary_to_term(Bin) of
+                Data when is_list(Data) ->
+                    try
+                        {ok, lists:foldl(fun manifest_module/2, #{}, Data)}
+                    catch
+                        _:_ ->
+                            {error, {manifest, File, malformed_manifest}}
+                    end;
+                _Other ->
+                    {error, {manifest, File, malformed_manifest}}
+            catch
+                error:badarg ->
+                    {error, {manifest, File, not_external_term_format}}
+            end;
+        {error, Reason} ->
+            {error, {manifest, File, Reason}}
+    end.
+
+manifest_module({Module, Lines}, Acc) when is_atom(Module), is_list(Lines) ->
+    Good = lists:usort([L || L <- Lines, is_integer(L), L > 0]),
+    maps:update_with(Module, fun(Ls) -> lists:umerge(Good, Ls) end,
+                     Good, Acc).
+
+%% Extend the merged coverdata with count-0 entries for every
+%% manifest line that was never hit. Modules present only in the
+%% manifest get all-zero records; modules present only in the
+%% coverdata are kept as-is.
+apply_manifest(Manifest, Merged) when map_size(Manifest) =:= 0 ->
+    Merged;
+apply_manifest(Manifest, Merged) ->
+    maps:fold(
+      fun(Module, Lines, Acc) ->
+              Hit = maps:get(Module, Acc, #{}),
+              Acc#{Module => maps:merge(maps:from_keys(Lines, 0), Hit)}
+      end, Merged, Manifest).
 
 %%%-----------------------------------------------------------------
 %%% LCOV output

--- a/lib/common_test/src/ct_cover_to_lcov.erl
+++ b/lib/common_test/src/ct_cover_to_lcov.erl
@@ -1,0 +1,198 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(ct_cover_to_lcov).
+-moduledoc false.
+
+%%% Convert the per-testcase coverage artifacts written by
+%%% cth_coverage into LCOV tracefile (.info) format, suitable for
+%%% genhtml, lcov tooling and coverage services.
+%%%
+%%% Each input file contains
+%%%
+%%%    term_to_binary([{Module, [{Line, Count}]}])
+%%%
+%%% with only executed (non-zero) lines present. All input files are
+%%% merged by summing counts per {Module, Line} before the LCOV
+%%% output is written.
+%%%
+%%% TODO: the sparse coverdata written by cth_coverage only contains
+%%%       EXECUTED lines, so this converter cannot emit DA records
+%%%       for instrumented-but-unexecuted lines. As a consequence LF
+%%%       equals the number of executed lines and every file appears
+%%%       fully covered (LH == LF) in LCOV consumers. To fix, feed
+%%%       this tool the full instrumented-line set per module: a
+%%%       single code:get_coverage(line, Module) call returns ALL
+%%%       instrumented lines including those with count 0 (which
+%%%       cth_coverage currently filters out for sparsity), and emit
+%%%       DA:<line>,0 for the un-hit ones.
+
+-export([convert/2, main/1]).
+
+-doc """
+Read all `InFiles`, merge their per-line execution counts, and write
+the result in LCOV tracefile format to `OutFile`.
+
+Unreadable or malformed input files are skipped with a warning on
+standard error.
+""".
+-spec convert(InFiles, OutFile) -> ok | {error, term()} when
+      InFiles :: [file:filename()],
+      OutFile :: file:filename().
+convert(InFiles, OutFile) when is_list(InFiles) ->
+    Merged = lists:foldl(fun merge_file/2, #{}, InFiles),
+    write_lcov(Merged, OutFile).
+
+-doc """
+Escript entry point.
+
+Usage: `ct_cover_to_lcov <out.info> <in1.coverdata> ...`
+
+If a single input argument is given and it is a directory, all
+`*.coverdata` files in it are converted.
+""".
+-spec main(Args :: [string()]) -> ok | no_return().
+main([OutFile, MaybeDir]) ->
+    InFiles =
+        case filelib:is_dir(MaybeDir) of
+            true ->
+                filelib:wildcard(filename:join(MaybeDir, "*.coverdata"));
+            false ->
+                [MaybeDir]
+        end,
+    run(InFiles, OutFile);
+main([OutFile | InFiles]) when InFiles =/= [] ->
+    run(InFiles, OutFile);
+main(_) ->
+    io:format(standard_error,
+              "usage: ct_cover_to_lcov <out.info> <in1.coverdata> ...~n"
+              "       ct_cover_to_lcov <out.info> <coverdata-dir>~n", []),
+    erlang:halt(1).
+
+run([], _OutFile) ->
+    io:format(standard_error,
+              "ct_cover_to_lcov: error: no input .coverdata files~n", []),
+    erlang:halt(1);
+run(InFiles, OutFile) ->
+    case convert(InFiles, OutFile) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            io:format(standard_error,
+                      "ct_cover_to_lcov: error: ~tp~n", [Reason]),
+            erlang:halt(1)
+    end.
+
+%%%-----------------------------------------------------------------
+%%% Reading and merging
+
+merge_file(File, Acc) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            try binary_to_term(Bin) of
+                Data when is_list(Data) ->
+                    try
+                        lists:foldl(fun merge_module/2, Acc, Data)
+                    catch
+                        _:_ ->
+                            warn(File, malformed_coverdata),
+                            Acc
+                    end;
+                _Other ->
+                    warn(File, malformed_coverdata),
+                    Acc
+            catch
+                error:badarg ->
+                    warn(File, not_external_term_format),
+                    Acc
+            end;
+        {error, Reason} ->
+            warn(File, Reason),
+            Acc
+    end.
+
+merge_module({Module, Lines}, Acc)
+  when is_atom(Module), is_list(Lines) ->
+    ModMap = lists:foldl(fun merge_line/2, maps:get(Module, Acc, #{}), Lines),
+    Acc#{Module => ModMap}.
+
+merge_line({Line, Count}, ModMap)
+  when is_integer(Line), Line > 0, is_integer(Count), Count >= 0 ->
+    maps:update_with(Line, fun(C) -> C + Count end, Count, ModMap).
+
+warn(File, Reason) ->
+    io:format(standard_error,
+              "ct_cover_to_lcov: warning: skipping ~ts: ~tp~n",
+              [File, Reason]).
+
+%%%-----------------------------------------------------------------
+%%% LCOV output
+
+write_lcov(Merged, OutFile) ->
+    Records = [module_record(Module, maps:get(Module, Merged)) ||
+                  Module <- lists:sort(maps:keys(Merged))],
+    file:write_file(OutFile, Records).
+
+module_record(Module, LineMap) ->
+    Lines = lists:sort(maps:to_list(LineMap)),
+    Hit = length([[] || {_Line, Count} <- Lines, Count > 0]),
+    ["SF:", source_file(Module), "\n",
+     [io_lib:format("DA:~w,~w~n", [Line, Count]) || {Line, Count} <- Lines],
+     io_lib:format("LF:~w~n", [length(Lines)]),
+     io_lib:format("LH:~w~n", [Hit]),
+     "end_of_record\n"].
+
+%% Best-effort resolution of the source file for Module. Never crashes;
+%% falls back to "Module.erl" when nothing better can be derived.
+source_file(Module) ->
+    Source = try Module:module_info(compile) of
+                 Info when is_list(Info) ->
+                     proplists:get_value(source, Info);
+                 _ ->
+                     undefined
+             catch
+                 _:_ ->
+                     undefined
+             end,
+    case Source of
+        [_ | _] ->
+            filename:absname(Source);
+        _ ->
+            source_from_beam(Module)
+    end.
+
+source_from_beam(Module) ->
+    Default = atom_to_list(Module) ++ ".erl",
+    try code:which(Module) of
+        Beam when is_list(Beam), Beam =/= [] ->
+            %% .../ebin/Module.beam -> .../src/Module.erl
+            AppDir = filename:dirname(filename:dirname(Beam)),
+            Src = filename:join([AppDir, "src", Default]),
+            case filelib:is_regular(Src) of
+                true -> filename:absname(Src);
+                false -> Default
+            end;
+        _ ->
+            Default
+    catch
+        _:_ ->
+            Default
+    end.

--- a/lib/common_test/src/cth_coverage.erl
+++ b/lib/common_test/src/cth_coverage.erl
@@ -1,0 +1,191 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(cth_coverage).
+-moduledoc false.
+
+%%% Common Test hook capturing per-testcase native line coverage.
+%%%
+%%% For every test case, the coverage counters of all natively
+%%% instrumented modules (see code:set_coverage_mode/1 and the
+%%% `line_coverage' compiler option) are reset before
+%%% init_per_testcase and read after end_per_testcase. The lines
+%%% executed by the test case (including its init/end_per_testcase)
+%%% are written to one file per test case:
+%%%
+%%%    <dir>/<Suite>.<Case>.coverdata
+%%%
+%%% containing term_to_binary([{Module, [{Line, Count}]}]) with only
+%%% lines that have a non-zero count (sparse). The output directory is
+%%% taken from the hook option {dir, Dir}, or the OS environment
+%%% variable CT_COVERAGE_DIR, defaulting to "./ct_coverage".
+%%%
+%%% This is v1 and only covers code running on the main test node.
+%%%
+%%% TODO: peer-node fan-out. Coverage executed on peer nodes started
+%%%       by a test case is not captured. Fan out
+%%%       code:reset_coverage/1 and code:get_coverage/2 via erpc to
+%%%       nodes() (peers must run with the same coverage mode) and
+%%%       merge the per-node results.
+%%% TODO: parallel-group serialization. In a parallel group, test
+%%%       cases overlap in time, so per-case reset/read attributes
+%%%       coverage to the wrong case. Detect parallel groups (see
+%%%       cth_log_redirect's use of tc_group_properties) and fall back
+%%%       to one bucket for the whole group, or serialize collection.
+%%% TODO: config-phase buckets. Coverage executed in
+%%%       init/end_per_suite and init/end_per_group is currently lost
+%%%       (reset at the next pre_init_per_testcase). Add the
+%%%       pre/post_init_per_suite and group callbacks and write
+%%%       "<Suite>.init_per_suite.coverdata"-style buckets.
+%%% TODO: native (C) coverage. When the emulator is built with gcov,
+%%%       dump/reset C-level coverage per test case as well (via
+%%%       erts_debug coverage support), so ERTS changes can be mapped
+%%%       to the test cases that exercise them.
+
+%% CTH Callbacks
+-export([id/1, init/2,
+         pre_init_per_testcase/4,
+         post_end_per_testcase/5,
+         terminate/1]).
+
+-behaviour(ct_hooks).
+
+-record(state, {enabled = false :: boolean(),
+                dir :: file:filename() | undefined,
+                level = line :: line,
+                modules = [] :: [module()]}).
+
+-define(DEFAULT_DIR, "ct_coverage").
+
+id(_Opts) ->
+    ?MODULE.
+
+init(_Id, Opts) ->
+    Enabled = code:coverage_support() andalso
+        code:get_coverage_mode() =/= none,
+    case Enabled of
+        true ->
+            Dir = filename:absname(output_dir(Opts)),
+            _ = filelib:ensure_path(Dir),
+            {ok, #state{enabled = true, dir = Dir, level = line}};
+        false ->
+            %% Log once and become a no-op.
+            logger:notice("cth_coverage: native coverage not available "
+                          "(coverage_support: ~w, coverage mode: ~w); "
+                          "per-testcase coverage collection is disabled",
+                          [code:coverage_support(),
+                           try code:get_coverage_mode()
+                           catch _:_ -> undefined end]),
+            {ok, #state{enabled = false}}
+    end.
+
+pre_init_per_testcase(_Suite, _TC, Config,
+                      #state{enabled = true, level = Level} = State) ->
+    Modules = instrumented_modules(Level),
+    _ = [reset_coverage(M) || M <- Modules],
+    {Config, State#state{modules = Modules}};
+pre_init_per_testcase(_Suite, _TC, Config, State) ->
+    {Config, State}.
+
+post_end_per_testcase(Suite, TC, _Config, Return,
+                      #state{enabled = true, level = Level} = State) ->
+    %% Re-scan for instrumented modules instead of using the list from
+    %% pre_init_per_testcase; modules loaded during the test case are
+    %% instrumented from load time and belong to this test case too.
+    Coverage =
+        lists:filtermap(
+          fun(M) ->
+                  case covered_lines(Level, M) of
+                      [] -> false;
+                      Lines -> {true, {M, Lines}}
+                  end
+          end, instrumented_modules(Level)),
+    ok = write_coverdata(State#state.dir, Suite, TC, Coverage),
+    {Return, State};
+post_end_per_testcase(_Suite, _TC, _Config, Return, State) ->
+    {Return, State}.
+
+terminate(_State) ->
+    ok.
+
+%%%-----------------------------------------------------------------
+%%% Internal functions
+
+output_dir(Opts) ->
+    case proplists:get_value(dir, Opts) of
+        undefined ->
+            case os:getenv("CT_COVERAGE_DIR") of
+                false -> ?DEFAULT_DIR;
+                EnvDir -> EnvDir
+            end;
+        Dir ->
+            Dir
+    end.
+
+%% All currently loaded modules that carry native coverage data.
+%% Only instrumented modules return data from code:get_coverage/2;
+%% all others raise badarg. Deliberately not cached across test cases
+%% since modules can be loaded (or reloaded) at any time during a run.
+instrumented_modules(Level) ->
+    [M || {M, _File} <- code:all_loaded(), has_coverage(Level, M)].
+
+has_coverage(Level, M) ->
+    try code:get_coverage(Level, M) of
+        _ -> true
+    catch
+        _:_ -> false
+    end.
+
+reset_coverage(M) ->
+    %% The module may have been purged since it was listed.
+    try code:reset_coverage(M)
+    catch _:_ -> ok
+    end.
+
+%% Lines with a non-zero execution count. In line_counters mode
+%% code:get_coverage(line, M) returns [{Line, Count}]; in line mode it
+%% returns [{Line, boolean()}], in which case true is treated as 1.
+covered_lines(Level, M) ->
+    try code:get_coverage(Level, M) of
+        LineData ->
+            [{Line, cov_count(Cov)} ||
+                {Line, Cov} <- LineData, Cov =/= false, Cov =/= 0]
+    catch
+        _:_ -> []
+    end.
+
+cov_count(true) -> 1;
+cov_count(N) when is_integer(N) -> N.
+
+write_coverdata(_Dir, _Suite, _TC, []) ->
+    ok;
+write_coverdata(Dir, Suite, TC, Coverage) ->
+    Name = lists:flatten(io_lib:format("~tw.~tw.coverdata", [Suite, TC])),
+    File = filename:join(Dir, Name),
+    _ = filelib:ensure_path(Dir),
+    case file:write_file(File, term_to_binary(Coverage)) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            logger:warning("cth_coverage: failed to write ~ts: ~p",
+                           [File, Reason]),
+            ok
+    end.

--- a/lib/common_test/src/cth_coverage.erl
+++ b/lib/common_test/src/cth_coverage.erl
@@ -75,10 +75,19 @@
 %%%       coverage to the wrong case. Detect parallel groups (see
 %%%       cth_log_redirect's use of tc_group_properties) and fall back
 %%%       to one bucket for the whole group, or serialize collection.
-%%% TODO: native (C) coverage. When the emulator is built with gcov,
-%%%       dump/reset C-level coverage per test case as well (via
-%%%       erts_debug coverage support), so ERTS changes can be mapped
-%%%       to the test cases that exercise them.
+%%% Native (C/JIT) coverage: on an emulator built with native coverage
+%%% (the clangcov or gcov build type) the emulator's own C and JIT
+%%% emitter coverage is also dumped, via erts_debug:coverage/1, into
+%%%
+%%%    <dir>/native/          (for clang, erl_<pid>.profraw per node)
+%%%
+%%% one file per emulator OS process. These are aggregate whole-run
+%%% counters -- unlike the BEAM line coverage they are NOT reset per
+%%% test case, so they carry no per-test attribution; convert them with
+%%% llvm-profdata + llvm-cov (clang) against the emulator binary. The
+%%% local node is dumped when the run ends; still-connected peer nodes
+%%% are also dumped after each test case (short-lived peers are subject
+%%% to the same not-captured limitation as the BEAM coverage above).
 
 %% CTH Callbacks
 -export([id/1, init/2,
@@ -100,6 +109,7 @@
 -behaviour(ct_hooks).
 
 -record(state, {enabled = false :: boolean(),
+                native = false :: boolean(),
                 dir :: file:filename() | undefined,
                 level = line :: line}).
 
@@ -121,7 +131,11 @@ init(_Id, Opts) ->
         true ->
             Dir = filename:absname(output_dir(Opts)),
             _ = filelib:ensure_path(Dir),
-            {ok, #state{enabled = true, dir = Dir, level = line}};
+            Native = native_supported(),
+            _ = Native andalso
+                    filelib:ensure_path(filename:join(Dir, "native")),
+            {ok, #state{enabled = true, native = Native,
+                        dir = Dir, level = line}};
         false ->
             %% No native coverage on this emulator (needs the JIT).
             %% Log once and become a no-op.
@@ -210,11 +224,17 @@ pre_init_per_testcase(_Suite, _TC, Config, State) ->
 post_end_per_testcase(Suite, TC, _Config, Return,
                       #state{enabled = true, level = Level} = State) ->
     ok = write_coverdata(State#state.dir, [Suite, TC], collect_all(Level)),
+    %% Best-effort: dump native coverage of any still-connected peer
+    %% nodes while they are alive (the local node is dumped at terminate).
+    ok = dump_native_peers(State),
     {Return, State};
 post_end_per_testcase(_Suite, _TC, _Config, Return, State) ->
     {Return, State}.
 
-terminate(#state{enabled = true, dir = Dir, level = Level}) ->
+terminate(#state{enabled = true, native = Native, dir = Dir, level = Level}) ->
+    %% Dump native (C/JIT) coverage of the local node and any nodes
+    %% still connected, then write the BEAM line manifest.
+    _ = Native andalso dump_native(Dir, [node() | nodes()]),
     ok = write_manifest(Dir, manifest_all(Level));
 terminate(_State) ->
     ok.
@@ -291,6 +311,49 @@ collect_local(Level) ->
               end, instrumented_modules(Level));
         false ->
             []
+    end.
+
+%%%-----------------------------------------------------------------
+%%% Native (C/JIT) coverage
+%%%
+%%% On a clangcov/gcov emulator, dump the emulator's own coverage
+%%% counters (C code plus the JIT emitter) via erts_debug:coverage/1.
+
+%% True iff this emulator supports native coverage (build_type
+%% clangcov/gcov). As a side effect the local counters are reset, so the
+%% collected coverage covers the test run rather than emulator start-up.
+native_supported() ->
+    try erts_debug:coverage(reset) of
+        ok -> true;
+        _ -> false
+    catch
+        _:_ -> false
+    end.
+
+%% Dump native coverage of any connected peer nodes; the local node is
+%% dumped once at terminate.
+dump_native_peers(#state{native = true, dir = Dir}) ->
+    dump_native(Dir, nodes());
+dump_native_peers(_State) ->
+    ok.
+
+%% Dump native coverage of the given nodes into <Dir>/native. A node
+%% that is down or does not support native coverage is skipped.
+dump_native(_Dir, []) ->
+    ok;
+dump_native(Dir, Nodes) ->
+    NativeDir = filename:join(Dir, "native"),
+    _ = [dump_native_on_node(N, NativeDir) || N <- Nodes],
+    ok.
+
+dump_native_on_node(Node, NativeDir) when Node =:= node() ->
+    try erts_debug:coverage({dump, NativeDir})
+    catch _:_ -> ok
+    end;
+dump_native_on_node(Node, NativeDir) ->
+    try erpc:call(Node, erts_debug, coverage, [{dump, NativeDir}],
+                  ?REMOTE_TIMEOUT)
+    catch _:_ -> ok
     end.
 
 %%%-----------------------------------------------------------------

--- a/lib/common_test/src/cth_coverage.erl
+++ b/lib/common_test/src/cth_coverage.erl
@@ -48,6 +48,17 @@
 %%%
 %%% Buckets with no executed lines produce no file.
 %%%
+%%% When the whole test run ends (hook terminate) a one-time line
+%%% manifest is written:
+%%%
+%%%    <dir>/coverage.manifest
+%%%
+%%% containing term_to_binary([{Module, [Line]}]) with ALL
+%%% instrumented lines of every instrumented module, including lines
+%%% never executed, unioned across all nodes. ct_cover_to_lcov uses
+%%% it to emit DA records with count 0 for un-hit lines, making the
+%%% LCOV LF/LH totals meaningful.
+%%%
 %%% Reset and collection fan out to all connected peer nodes
 %%% ([node() | nodes()]). The instrumented-modules probe runs on each
 %%% node (each node has its own loaded set and its own counters), via
@@ -84,7 +95,7 @@
          terminate/1]).
 
 %% Exported only for erpc use on peer nodes; not part of the hook API.
--export([reset_local/1, collect_local/1]).
+-export([reset_local/1, collect_local/1, manifest_local/1]).
 
 -behaviour(ct_hooks).
 
@@ -203,6 +214,8 @@ post_end_per_testcase(Suite, TC, _Config, Return,
 post_end_per_testcase(_Suite, _TC, _Config, Return, State) ->
     {Return, State}.
 
+terminate(#state{enabled = true, dir = Dir, level = Level}) ->
+    ok = write_manifest(Dir, manifest_all(Level));
 terminate(_State) ->
     ok.
 
@@ -278,6 +291,81 @@ collect_local(Level) ->
               end, instrumented_modules(Level));
         false ->
             []
+    end.
+
+%%%-----------------------------------------------------------------
+%%% Line manifest (all instrumented lines, executed or not)
+
+%% The full instrumented-line set from every node, unioned per module.
+manifest_all(Level) ->
+    merge_manifest([manifest_on_node(N, Level) || N <- coverage_nodes()]).
+
+manifest_on_node(Node, Level) when Node =:= node() ->
+    manifest_local(Level);
+manifest_on_node(Node, Level) ->
+    %% As for collection: a node that is down, does not have this
+    %% module, or does not support coverage is skipped silently.
+    try erpc:call(Node, ?MODULE, manifest_local, [Level], ?REMOTE_TIMEOUT)
+    catch _:_ -> []
+    end.
+
+%% Runs on the node whose instrumented-line set is read (locally or
+%% via erpc). Same probe as collect_local/1 but keeps EVERY
+%% instrumented line, not only those with a non-zero count.
+manifest_local(Level) ->
+    case code:coverage_support() of
+        true ->
+            lists:filtermap(
+              fun(M) ->
+                      case instrumented_lines(Level, M) of
+                          [] -> false;
+                          Lines -> {true, {M, Lines}}
+                      end
+              end, instrumented_modules(Level));
+        false ->
+            []
+    end.
+
+%% Every instrumented line of M, regardless of execution count.
+instrumented_lines(Level, M) ->
+    try code:get_coverage(Level, M) of
+        LineData -> [Line || {Line, _Cov} <- LineData, is_integer(Line)]
+    catch
+        _:_ -> []
+    end.
+
+%% Union per-node manifests per module. As in merge_coverage/1,
+%% entries without the expected shape are ignored.
+merge_manifest(PerNode) ->
+    Merged = lists:foldl(fun merge_manifest_node/2, #{}, PerNode),
+    lists:sort([{M, lists:usort(Lines)} || {M, Lines} <- maps:to_list(Merged)]).
+
+merge_manifest_node(NodeLines, Acc) when is_list(NodeLines) ->
+    lists:foldl(fun merge_manifest_module/2, Acc, NodeLines);
+merge_manifest_node(_Bad, Acc) ->
+    Acc.
+
+merge_manifest_module({M, Lines}, Acc) when is_atom(M), is_list(Lines) ->
+    Good = [Line || Line <- Lines, is_integer(Line)],
+    maps:update_with(M, fun(Ls) -> Good ++ Ls end, Good, Acc);
+merge_manifest_module(_Bad, Acc) ->
+    Acc.
+
+%% Write the one-time line manifest, read by ct_cover_to_lcov to emit
+%% DA:<Line>,0 records for lines never executed. An empty manifest
+%% (no instrumented modules) produces no file.
+write_manifest(_Dir, []) ->
+    ok;
+write_manifest(Dir, Manifest) ->
+    File = filename:join(Dir, "coverage.manifest"),
+    _ = filelib:ensure_path(Dir),
+    case file:write_file(File, term_to_binary(Manifest)) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            logger:warning("cth_coverage: failed to write ~ts: ~p",
+                           [File, Reason]),
+            ok
     end.
 
 %% Merge per-node sparse coverage lists, summing counts per

--- a/lib/common_test/src/cth_coverage.erl
+++ b/lib/common_test/src/cth_coverage.erl
@@ -79,21 +79,21 @@ id(_Opts) ->
     ?MODULE.
 
 init(_Id, Opts) ->
-    Enabled = code:coverage_support() andalso
-        code:get_coverage_mode() =/= none,
-    case Enabled of
+    %% Gate only on coverage_support(): modules compiled with
+    %% +force_line_counters are line-counted regardless of the global
+    %% coverage mode, so the per-module probe (instrumented_modules/1)
+    %% is what decides what to collect -- not code:get_coverage_mode/0.
+    case code:coverage_support() of
         true ->
             Dir = filename:absname(output_dir(Opts)),
             _ = filelib:ensure_path(Dir),
             {ok, #state{enabled = true, dir = Dir, level = line}};
         false ->
+            %% No native coverage on this emulator (needs the JIT).
             %% Log once and become a no-op.
-            logger:notice("cth_coverage: native coverage not available "
-                          "(coverage_support: ~w, coverage mode: ~w); "
-                          "per-testcase coverage collection is disabled",
-                          [code:coverage_support(),
-                           try code:get_coverage_mode()
-                           catch _:_ -> undefined end]),
+            logger:notice("cth_coverage: native coverage not supported on "
+                          "this emulator; per-testcase coverage collection "
+                          "is disabled"),
             {ok, #state{enabled = false}}
     end.
 

--- a/lib/common_test/src/cth_coverage.erl
+++ b/lib/common_test/src/cth_coverage.erl
@@ -38,23 +38,32 @@
 %%% taken from the hook option {dir, Dir}, or the OS environment
 %%% variable CT_COVERAGE_DIR, defaulting to "./ct_coverage".
 %%%
-%%% This is v1 and only covers code running on the main test node.
+%%% Coverage executed in the configuration functions is captured into
+%%% separate bucket files of the same format:
 %%%
-%%% TODO: peer-node fan-out. Coverage executed on peer nodes started
-%%%       by a test case is not captured. Fan out
-%%%       code:reset_coverage/1 and code:get_coverage/2 via erpc to
-%%%       nodes() (peers must run with the same coverage mode) and
-%%%       merge the per-node results.
+%%%    <dir>/<Suite>.init_per_suite.coverdata
+%%%    <dir>/<Suite>.end_per_suite.coverdata
+%%%    <dir>/<Suite>.<Group>.init_per_group.coverdata
+%%%    <dir>/<Suite>.<Group>.end_per_group.coverdata
+%%%
+%%% Buckets with no executed lines produce no file.
+%%%
+%%% Reset and collection fan out to all connected peer nodes
+%%% ([node() | nodes()]). The instrumented-modules probe runs on each
+%%% node (each node has its own loaded set and its own counters), via
+%%% erpc for remote nodes, and the per-node results are merged by
+%%% summing the counts of each {Module, Line} across nodes. A node
+%%% that does not support native coverage, cannot load this module, or
+%%% fails/times out mid-call is skipped silently and never fails the
+%%% test case. Peer nodes stopped before the coverage is read (for
+%%% example in the middle of a test case) are not captured; hidden
+%%% nodes are not visited.
+%%%
 %%% TODO: parallel-group serialization. In a parallel group, test
 %%%       cases overlap in time, so per-case reset/read attributes
 %%%       coverage to the wrong case. Detect parallel groups (see
 %%%       cth_log_redirect's use of tc_group_properties) and fall back
 %%%       to one bucket for the whole group, or serialize collection.
-%%% TODO: config-phase buckets. Coverage executed in
-%%%       init/end_per_suite and init/end_per_group is currently lost
-%%%       (reset at the next pre_init_per_testcase). Add the
-%%%       pre/post_init_per_suite and group callbacks and write
-%%%       "<Suite>.init_per_suite.coverdata"-style buckets.
 %%% TODO: native (C) coverage. When the emulator is built with gcov,
 %%%       dump/reset C-level coverage per test case as well (via
 %%%       erts_debug coverage support), so ERTS changes can be mapped
@@ -62,18 +71,32 @@
 
 %% CTH Callbacks
 -export([id/1, init/2,
+         pre_init_per_suite/3,
+         post_init_per_suite/4,
+         pre_end_per_suite/3,
+         post_end_per_suite/4,
+         pre_init_per_group/4,
+         post_init_per_group/5,
+         pre_end_per_group/4,
+         post_end_per_group/5,
          pre_init_per_testcase/4,
          post_end_per_testcase/5,
          terminate/1]).
+
+%% Exported only for erpc use on peer nodes; not part of the hook API.
+-export([reset_local/1, collect_local/1]).
 
 -behaviour(ct_hooks).
 
 -record(state, {enabled = false :: boolean(),
                 dir :: file:filename() | undefined,
-                level = line :: line,
-                modules = [] :: [module()]}).
+                level = line :: line}).
 
 -define(DEFAULT_DIR, "ct_coverage").
+
+%% Upper bound for each remote reset/collect call so that a wedged
+%% peer node cannot hang the test run.
+-define(REMOTE_TIMEOUT, 15000).
 
 id(_Opts) ->
     ?MODULE.
@@ -97,28 +120,85 @@ init(_Id, Opts) ->
             {ok, #state{enabled = false}}
     end.
 
+%%%-----------------------------------------------------------------
+%%% Suite configuration buckets
+
+pre_init_per_suite(_Suite, InitData,
+                   #state{enabled = true, level = Level} = State) ->
+    ok = reset_all(Level),
+    {InitData, State};
+pre_init_per_suite(_Suite, InitData, State) ->
+    {InitData, State}.
+
+post_init_per_suite(Suite, _Config, Return,
+                    #state{enabled = true, level = Level} = State) ->
+    ok = write_coverdata(State#state.dir, [Suite, init_per_suite],
+                         collect_all(Level)),
+    {Return, State};
+post_init_per_suite(_Suite, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_suite(_Suite, EndData,
+                  #state{enabled = true, level = Level} = State) ->
+    ok = reset_all(Level),
+    {EndData, State};
+pre_end_per_suite(_Suite, EndData, State) ->
+    {EndData, State}.
+
+post_end_per_suite(Suite, _Config, Return,
+                   #state{enabled = true, level = Level} = State) ->
+    ok = write_coverdata(State#state.dir, [Suite, end_per_suite],
+                         collect_all(Level)),
+    {Return, State};
+post_end_per_suite(_Suite, _Config, Return, State) ->
+    {Return, State}.
+
+%%%-----------------------------------------------------------------
+%%% Group configuration buckets
+
+pre_init_per_group(_Suite, _Group, InitData,
+                   #state{enabled = true, level = Level} = State) ->
+    ok = reset_all(Level),
+    {InitData, State};
+pre_init_per_group(_Suite, _Group, InitData, State) ->
+    {InitData, State}.
+
+post_init_per_group(Suite, Group, _Config, Return,
+                    #state{enabled = true, level = Level} = State) ->
+    ok = write_coverdata(State#state.dir, [Suite, Group, init_per_group],
+                         collect_all(Level)),
+    {Return, State};
+post_init_per_group(_Suite, _Group, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_group(_Suite, _Group, EndData,
+                  #state{enabled = true, level = Level} = State) ->
+    ok = reset_all(Level),
+    {EndData, State};
+pre_end_per_group(_Suite, _Group, EndData, State) ->
+    {EndData, State}.
+
+post_end_per_group(Suite, Group, _Config, Return,
+                   #state{enabled = true, level = Level} = State) ->
+    ok = write_coverdata(State#state.dir, [Suite, Group, end_per_group],
+                         collect_all(Level)),
+    {Return, State};
+post_end_per_group(_Suite, _Group, _Config, Return, State) ->
+    {Return, State}.
+
+%%%-----------------------------------------------------------------
+%%% Test cases
+
 pre_init_per_testcase(_Suite, _TC, Config,
                       #state{enabled = true, level = Level} = State) ->
-    Modules = instrumented_modules(Level),
-    _ = [reset_coverage(M) || M <- Modules],
-    {Config, State#state{modules = Modules}};
+    ok = reset_all(Level),
+    {Config, State};
 pre_init_per_testcase(_Suite, _TC, Config, State) ->
     {Config, State}.
 
 post_end_per_testcase(Suite, TC, _Config, Return,
                       #state{enabled = true, level = Level} = State) ->
-    %% Re-scan for instrumented modules instead of using the list from
-    %% pre_init_per_testcase; modules loaded during the test case are
-    %% instrumented from load time and belong to this test case too.
-    Coverage =
-        lists:filtermap(
-          fun(M) ->
-                  case covered_lines(Level, M) of
-                      [] -> false;
-                      Lines -> {true, {M, Lines}}
-                  end
-          end, instrumented_modules(Level)),
-    ok = write_coverdata(State#state.dir, Suite, TC, Coverage),
+    ok = write_coverdata(State#state.dir, [Suite, TC], collect_all(Level)),
     {Return, State};
 post_end_per_testcase(_Suite, _TC, _Config, Return, State) ->
     {Return, State}.
@@ -139,6 +219,95 @@ output_dir(Opts) ->
         Dir ->
             Dir
     end.
+
+%% The main test node and all connected (visible) peer nodes.
+coverage_nodes() ->
+    [node() | nodes()].
+
+%% Reset the coverage counters on every node.
+reset_all(Level) ->
+    _ = [reset_on_node(N, Level) || N <- coverage_nodes()],
+    ok.
+
+%% Collect the coverage from every node and merge the results, summing
+%% the counts of each {Module, Line} across nodes. A line is covered
+%% if any node executed it.
+collect_all(Level) ->
+    merge_coverage([collect_on_node(N, Level) || N <- coverage_nodes()]).
+
+reset_on_node(Node, Level) when Node =:= node() ->
+    reset_local(Level);
+reset_on_node(Node, Level) ->
+    %% A node that is down, does not have this module, or does not
+    %% support coverage must never fail the test case; skip it.
+    try erpc:call(Node, ?MODULE, reset_local, [Level], ?REMOTE_TIMEOUT)
+    catch _:_ -> ok
+    end.
+
+collect_on_node(Node, Level) when Node =:= node() ->
+    collect_local(Level);
+collect_on_node(Node, Level) ->
+    try erpc:call(Node, ?MODULE, collect_local, [Level], ?REMOTE_TIMEOUT)
+    catch _:_ -> []
+    end.
+
+%% Runs on the node whose coverage is reset (locally or via erpc).
+reset_local(Level) ->
+    case code:coverage_support() of
+        true ->
+            _ = [reset_coverage(M) || M <- instrumented_modules(Level)],
+            ok;
+        false ->
+            ok
+    end.
+
+%% Runs on the node whose coverage is read (locally or via erpc).
+%% The instrumented-modules probe is re-run on every collection
+%% instead of reusing the list from the reset; modules loaded since
+%% the reset are instrumented from load time and belong to this
+%% bucket too.
+collect_local(Level) ->
+    case code:coverage_support() of
+        true ->
+            lists:filtermap(
+              fun(M) ->
+                      case covered_lines(Level, M) of
+                          [] -> false;
+                          Lines -> {true, {M, Lines}}
+                      end
+              end, instrumented_modules(Level));
+        false ->
+            []
+    end.
+
+%% Merge per-node sparse coverage lists, summing counts per
+%% {Module, Line}. Entries that do not have the expected shape (for
+%% example from a peer running a different version of this module)
+%% are ignored rather than failing the test case.
+merge_coverage([NodeCov]) ->
+    %% Common case: no peer nodes.
+    NodeCov;
+merge_coverage(PerNode) ->
+    Merged = lists:foldl(fun merge_node/2, #{}, PerNode),
+    lists:sort([{M, lists:sort(maps:to_list(Lines))}
+                || {M, Lines} <- maps:to_list(Merged)]).
+
+merge_node(NodeCov, Acc) when is_list(NodeCov) ->
+    lists:foldl(fun merge_module/2, Acc, NodeCov);
+merge_node(_Bad, Acc) ->
+    Acc.
+
+merge_module({M, Lines}, Acc) when is_atom(M), is_list(Lines) ->
+    LineMap =
+        lists:foldl(
+          fun({Line, Count}, LM) when is_integer(Line), is_integer(Count) ->
+                  maps:update_with(Line, fun(C) -> C + Count end, Count, LM);
+             (_Bad, LM) ->
+                  LM
+          end, maps:get(M, Acc, #{}), Lines),
+    Acc#{M => LineMap};
+merge_module(_Bad, Acc) ->
+    Acc.
 
 %% All currently loaded modules that carry native coverage data.
 %% Only instrumented modules return data from code:get_coverage/2;
@@ -175,10 +344,15 @@ covered_lines(Level, M) ->
 cov_count(true) -> 1;
 cov_count(N) when is_integer(N) -> N.
 
-write_coverdata(_Dir, _Suite, _TC, []) ->
+%% Write one coverage bucket. NameParts (atoms) are joined with "."
+%% into the file name, e.g. [Suite, TC] -> "<Suite>.<TC>.coverdata".
+%% Empty buckets produce no file.
+write_coverdata(_Dir, _NameParts, []) ->
     ok;
-write_coverdata(Dir, Suite, TC, Coverage) ->
-    Name = lists:flatten(io_lib:format("~tw.~tw.coverdata", [Suite, TC])),
+write_coverdata(Dir, NameParts, Coverage) ->
+    Name = lists:flatten(
+             [lists:join($., [io_lib:format("~tw", [P]) || P <- NameParts]),
+              ".coverdata"]),
     File = filename:join(Dir, Name),
     _ = filelib:ensure_path(Dir),
     case file:write_file(File, term_to_binary(Coverage)) of

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -2093,6 +2093,7 @@ timetrap_scale_factor() ->
 	{ 6, fun() -> is_debug() end},
 	{10, fun() -> is_cover() end},
         {10, fun() -> is_valgrind() end},
+        {10, fun() -> is_gcov() end},
         {2,  fun() -> is_asan() end}
     ]).
 
@@ -3102,6 +3103,10 @@ is_valgrind() ->
 %% Returns true if address-sanitizer is running, else false
 is_asan() ->
     memory_checker() =:= asan.
+
+%% Returns true if the emulator is a gcov build, else false
+is_gcov() ->
+    erlang:system_info(build_type) =:= gcov.
 
 %% Returns the error checker running (valgrind | asan | none).
 memory_checker() ->

--- a/lib/common_test/test/Makefile
+++ b/lib/common_test/test/Makefile
@@ -80,7 +80,8 @@ MODULES= \
 	ct_util_SUITE \
 	ct_tc_repeat_SUITE \
 	ct_property_test_SUITE \
-	ct_doctest_SUITE
+	ct_doctest_SUITE \
+	ct_coverage_SUITE
 
 ERL_FILES= $(MODULES:%=%.erl)
 HRL_FILES= test_server_test_lib.hrl

--- a/lib/common_test/test/ct_coverage_SUITE.erl
+++ b/lib/common_test/test/ct_coverage_SUITE.erl
@@ -45,14 +45,16 @@
 -include_lib("common_test/include/ct.hrl").
 
 -export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
--export([per_testcase_isolation/1, config_phase_buckets/1]).
+-export([per_testcase_isolation/1, config_phase_buckets/1,
+         report_generation/1]).
 
 suite() ->
     [{timetrap, {minutes, 2}}].
 
 all() ->
     [per_testcase_isolation,
-     config_phase_buckets].
+     config_phase_buckets,
+     report_generation].
 
 init_per_suite(Config) ->
     case code:coverage_support() of
@@ -137,6 +139,44 @@ config_phase_buckets(Config) ->
     assert_not_covered([helper_line(a), helper_line(b), helper_line(si)],
                        Ipg, init_per_group),
     ok.
+
+%% Render the per-testcase coverdata written by the inner run as an HTML
+%% attribution report and verify that a source line is attributed to
+%% exactly the test case that executed it.
+report_generation(Config) ->
+    CovDir = proplists:get_value(cov_dir, Config),
+    WorkDir = proplists:get_value(work_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
+    OutDir = filename:join(PrivDir, "attrib_html"),
+    Files = filelib:wildcard(filename:join(CovDir, "*.coverdata")),
+    %% covhelper/covinner_SUITE live in a flat work dir, not an ebin/src
+    %% app layout, so tell the reporter where their sources are.
+    SMap = #{covhelper => filename:join(WorkDir, "covhelper.erl"),
+             covinner_SUITE => filename:join(WorkDir, "covinner_SUITE.erl")},
+    Manifest = filename:join(CovDir, "coverage.manifest"),
+    Opts = [{source_map, SMap}, {title, "covinner attribution"}] ++
+           [{manifest, Manifest} || filelib:is_regular(Manifest)],
+    ok = ct_cover_to_html:convert(Files, OutDir, Opts),
+    true = filelib:is_regular(filename:join(OutDir, "index.html")),
+    HelperPage = filename:join(OutDir, "covhelper.html"),
+    true = filelib:is_regular(HelperPage),
+    {ok, Bin} = file:read_file(HelperPage),
+    Html = unicode:characters_to_list(Bin),
+    %% covhelper:a/0 sits alone on helper_line(a) and is executed only by
+    %% tc_a; likewise b/0 by tc_b. The embedded attribution must say so.
+    assert_attributed(Html, helper_line(a), "covinner_SUITE.tc_a"),
+    assert_attributed(Html, helper_line(b), "covinner_SUITE.tc_b"),
+    %% The source was supplied, so the page must carry it (not the fallback).
+    nomatch = string:find(Html, "source not available"),
+    ok.
+
+assert_attributed(Html, Line, TestId) ->
+    Expect = lists:flatten(
+               io_lib:format("\"~w\":{\"n\":1,\"t\":[\"~ts\"]}", [Line, TestId])),
+    case string:find(Html, Expect) of
+        nomatch -> ct:fail({attribution_missing, Line, TestId, Expect});
+        _ -> ok
+    end.
 
 %%%-------------------------------------------------------------------
 %%% Generated modules

--- a/lib/common_test/test/ct_coverage_SUITE.erl
+++ b/lib/common_test/test/ct_coverage_SUITE.erl
@@ -1,0 +1,232 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%%-------------------------------------------------------------------
+%%% @doc Test of the cth_coverage hook, which captures per-testcase
+%%% native line coverage into one coverdata file per test case, plus
+%%% separate bucket files for the configuration functions
+%%% (init/end_per_suite and init/end_per_group).
+%%%
+%%% A tiny helper module (covhelper) and an inner test suite
+%%% (covinner_SUITE) are generated and compiled with the compiler
+%%% options `line_coverage' and `force_line_counters' so that they are
+%%% line-counted from load time, regardless of the global coverage
+%%% mode. The inner suite is then executed with ct:run_test/1 on a
+%%% peer node (Common Test cannot be started recursively on the test
+%%% node itself) with cth_coverage installed, and the coverdata files
+%%% it produces are inspected.
+%%%
+%%% Note: per_testcase_isolation performs the inner test run;
+%%% config_phase_buckets examines the config-phase buckets written by
+%%% that same run, so the cases must execute in the order of all/0.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(ct_coverage_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
+-export([per_testcase_isolation/1, config_phase_buckets/1]).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [per_testcase_isolation,
+     config_phase_buckets].
+
+init_per_suite(Config) ->
+    case code:coverage_support() of
+        false ->
+            {skip, "native coverage not supported on this emulator "
+                   "(requires the JIT)"};
+        true ->
+            PrivDir = proplists:get_value(priv_dir, Config),
+            WorkDir = filename:join(PrivDir, "cov_work"),
+            CovDir = filename:join(PrivDir, "coverdata"),
+            InnerLogDir = filename:join(PrivDir, "inner_logs"),
+            ok = filelib:ensure_path(WorkDir),
+            ok = filelib:ensure_path(CovDir),
+            ok = filelib:ensure_path(InnerLogDir),
+            ok = write_and_compile(WorkDir, "covhelper.erl", helper_src()),
+            ok = write_and_compile(WorkDir, "covinner_SUITE.erl", inner_src()),
+            [{work_dir, WorkDir},
+             {cov_dir, CovDir},
+             {inner_logdir, InnerLogDir} | Config]
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%%-------------------------------------------------------------------
+%%% Test cases
+
+%% Run the inner suite under cth_coverage on a peer node and check
+%% that each test case gets its own coverdata file containing exactly
+%% the helper lines that this test case (and nothing else) executed.
+per_testcase_isolation(Config) ->
+    WorkDir = proplists:get_value(work_dir, Config),
+    CovDir = proplists:get_value(cov_dir, Config),
+    InnerLogDir = proplists:get_value(inner_logdir, Config),
+    %% The output directory is communicated to the hook through the
+    %% CT_COVERAGE_DIR environment variable of the peer node.
+    {ok, Peer, Node} = ?CT_PEER(#{args => ["-pa", WorkDir],
+                                  env => [{"CT_COVERAGE_DIR", CovDir}]}),
+    Opts = [{dir, WorkDir},
+            {suite, covinner_SUITE},
+            {ct_hooks, [cth_coverage]},
+            {logdir, InnerLogDir},
+            {auto_compile, false}],
+    Result = try
+                 erpc:call(Node, ct, run_test, [Opts], 90000)
+             after
+                 peer:stop(Peer)
+             end,
+    case Result of
+        {2, 0, {0, 0}} ->
+            ok;
+        Other ->
+            ct:fail({unexpected_inner_run_result, Other})
+    end,
+    TcA = helper_cov(read_coverdata(CovDir, "covinner_SUITE.tc_a.coverdata")),
+    TcB = helper_cov(read_coverdata(CovDir, "covinner_SUITE.tc_b.coverdata")),
+    %% tc_a executed covhelper:a/0 and nothing else in covhelper.
+    assert_covered(helper_line(a), TcA, {covhelper, a, tc_a}),
+    assert_not_covered([helper_line(b), helper_line(si), helper_line(gi)],
+                       TcA, tc_a),
+    %% tc_b executed covhelper:b/0 and nothing else in covhelper.
+    assert_covered(helper_line(b), TcB, {covhelper, b, tc_b}),
+    assert_not_covered([helper_line(a), helper_line(si), helper_line(gi)],
+                       TcB, tc_b),
+    ok.
+
+%% Coverage executed in the configuration functions must end up in the
+%% per-phase bucket files, not in any test case file. Examines the
+%% coverdata written by the inner run in per_testcase_isolation.
+config_phase_buckets(Config) ->
+    CovDir = proplists:get_value(cov_dir, Config),
+    Ips = helper_cov(
+            read_coverdata(CovDir,
+                           "covinner_SUITE.init_per_suite.coverdata")),
+    assert_covered(helper_line(si), Ips, {covhelper, si, init_per_suite}),
+    assert_not_covered([helper_line(a), helper_line(b), helper_line(gi)],
+                       Ips, init_per_suite),
+    Ipg = helper_cov(
+            read_coverdata(CovDir,
+                           "covinner_SUITE.g.init_per_group.coverdata")),
+    assert_covered(helper_line(gi), Ipg, {covhelper, gi, init_per_group}),
+    assert_not_covered([helper_line(a), helper_line(b), helper_line(si)],
+                       Ipg, init_per_group),
+    ok.
+
+%%%-------------------------------------------------------------------
+%%% Generated modules
+%%%
+%%% Each covhelper function sits alone on its own line, so executing a
+%%% function bumps the counter of exactly one known line.
+
+helper_src() ->
+    ["-module(covhelper).",
+     "-export([a/0, b/0, si/0, gi/0]).",
+     "a() -> ok_a.",
+     "b() -> ok_b.",
+     "si() -> ok_si.",
+     "gi() -> ok_gi."].
+
+inner_src() ->
+    ["-module(covinner_SUITE).",
+     "-export([suite/0, all/0, groups/0,",
+     "         init_per_suite/1, end_per_suite/1,",
+     "         init_per_group/2, end_per_group/2,",
+     "         tc_a/1, tc_b/1]).",
+     "suite() -> [{timetrap, {seconds, 30}}].",
+     "all() -> [{group, g}].",
+     "groups() -> [{g, [], [tc_a, tc_b]}].",
+     "init_per_suite(Config) -> ok_si = covhelper:si(), Config.",
+     "end_per_suite(_Config) -> ok.",
+     "init_per_group(g, Config) -> ok_gi = covhelper:gi(), Config.",
+     "end_per_group(g, _Config) -> ok.",
+     "tc_a(_Config) -> ok_a = covhelper:a(), ok.",
+     "tc_b(_Config) -> ok_b = covhelper:b(), ok."].
+
+%% Source line number of a covhelper function's single-line body.
+helper_line(Fun) ->
+    line_of(atom_to_list(Fun) ++ "() ->", helper_src()).
+
+line_of(Prefix, Lines) ->
+    line_of(Prefix, Lines, 1).
+
+line_of(Prefix, [Line | Lines], N) ->
+    case lists:prefix(Prefix, Line) of
+        true -> N;
+        false -> line_of(Prefix, Lines, N + 1)
+    end.
+
+write_and_compile(Dir, FileName, SrcLines) ->
+    File = filename:join(Dir, FileName),
+    Src = [[Line, $\n] || Line <- SrcLines],
+    ok = file:write_file(File, Src),
+    case compile:file(File, [line_coverage, force_line_counters,
+                             {outdir, Dir}, report, return]) of
+        {ok, _Mod, _Warnings} ->
+            ok;
+        Error ->
+            ct:fail({compile_failed, File, Error})
+    end.
+
+%%%-------------------------------------------------------------------
+%%% Coverdata helpers
+
+%% A coverdata file contains term_to_binary([{Module, [{Line, Count}]}])
+%% with only non-zero lines.
+read_coverdata(CovDir, Name) ->
+    File = filename:join(CovDir, Name),
+    case file:read_file(File) of
+        {ok, Bin} ->
+            binary_to_term(Bin);
+        {error, Reason} ->
+            ct:fail({missing_coverdata, File, Reason})
+    end.
+
+%% The [{Line, Count}] entry for covhelper; the generated inner suite
+%% is instrumented too, so other modules may legitimately appear.
+helper_cov(Coverage) when is_list(Coverage) ->
+    case lists:keyfind(covhelper, 1, Coverage) of
+        {covhelper, Lines} -> Lines;
+        false -> []
+    end.
+
+assert_covered(Line, Lines, What) ->
+    case lists:keyfind(Line, 1, Lines) of
+        {Line, Count} when is_integer(Count), Count >= 1 ->
+            ok;
+        Other ->
+            ct:fail({line_not_covered, What, Line, Other, Lines})
+    end.
+
+assert_not_covered(ExcludedLines, Lines, What) ->
+    case [L || L <- ExcludedLines, lists:keymember(L, 1, Lines)] of
+        [] ->
+            ok;
+        Leaked ->
+            ct:fail({unexpected_lines_covered, What, Leaked, Lines})
+    end.

--- a/lib/kernel/src/erts_debug.erl
+++ b/lib/kernel/src/erts_debug.erl
@@ -36,7 +36,7 @@
 
 %%% BIFs
 
--export([breakpoint/2, disassemble/1, dist_ext_to_term/2,
+-export([breakpoint/2, coverage/1, disassemble/1, dist_ext_to_term/2,
          flat_size/1, get_internal_state/1, instructions/0,
          interpreter_size/0,
          map_info/1, same/2, set_internal_state/2,
@@ -106,6 +106,14 @@ copy_shared(Term) ->
       CopyLiterals :: true | false.
 
 copy_shared(_, _) ->
+    erlang:nif_error(undef).
+
+%% Reset or dump gcov coverage counters for the emulator itself.
+%% Returns 'not_supported' unless the emulator is a gcov build.
+-spec coverage(reset | {dump, Dir}) -> ok | not_supported when
+      Dir :: file:name_all().
+
+coverage(_) ->
     erlang:nif_error(undef).
 
 -spec get_internal_state(W) -> term() when

--- a/make/app_targets.mk
+++ b/make/app_targets.mk
@@ -30,6 +30,24 @@ test:
 	  $(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
 endif
 
+# Turn the per-testcase coverdata collected by `make test COVERAGE=yes`
+# (see $(ERL_TOP)/HOWTO/DEVELOPMENT.md) into an LCOV tracefile and an
+# interactive per-testcase attribution report.
+COVERAGE_DIR ?= make_test_dir/coverage
+.PHONY: coverage_report
+coverage_report:
+	@test -f "$(COVERAGE_DIR)/coverage.manifest" || { \
+	  echo "No coverdata in $(COVERAGE_DIR). Run 'make test COVERAGE=yes' first."; \
+	  exit 1; }
+	$(ERL_TOP)/bin/escript $(ERL_TOP)/lib/common_test/ebin/ct_cover_to_lcov.beam \
+	  --manifest "$(COVERAGE_DIR)/coverage.manifest" \
+	  "$(COVERAGE_DIR)/coverage.info" "$(COVERAGE_DIR)"
+	$(ERL_TOP)/bin/escript $(ERL_TOP)/lib/common_test/ebin/ct_cover_to_html.beam \
+	  --manifest "$(COVERAGE_DIR)/coverage.manifest" --max-per-line 5 \
+	  "$(COVERAGE_DIR)/html" "$(COVERAGE_DIR)"
+	@echo "LCOV tracefile:     $(COVERAGE_DIR)/coverage.info"
+	@echo "Attribution report: $(COVERAGE_DIR)/html/index.html"
+
 docs: $(filter src java_src, $(SUB_DIRECTORIES))
 
 info:

--- a/make/app_targets.mk
+++ b/make/app_targets.mk
@@ -30,23 +30,37 @@ test:
 	  $(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
 endif
 
-# Turn the per-testcase coverdata collected by `make test COVERAGE=yes`
-# (see $(ERL_TOP)/HOWTO/DEVELOPMENT.md) into an LCOV tracefile and an
-# interactive per-testcase attribution report.
+# Turn the coverage collected by `make test COVERAGE=yes` into reports:
+# the per-testcase BEAM line coverage into an LCOV tracefile + interactive
+# attribution report, and, if the tests ran on a clangcov emulator, the
+# native C/JIT coverage into an LCOV tracefile (see HOWTO/DEVELOPMENT.md).
 COVERAGE_DIR ?= make_test_dir/coverage
 .PHONY: coverage_report
 coverage_report:
-	@test -f "$(COVERAGE_DIR)/coverage.manifest" || { \
-	  echo "No coverdata in $(COVERAGE_DIR). Run 'make test COVERAGE=yes' first."; \
-	  exit 1; }
-	$(ERL_TOP)/bin/escript $(ERL_TOP)/lib/common_test/ebin/ct_cover_to_lcov.beam \
-	  --manifest "$(COVERAGE_DIR)/coverage.manifest" \
-	  "$(COVERAGE_DIR)/coverage.info" "$(COVERAGE_DIR)"
-	$(ERL_TOP)/bin/escript $(ERL_TOP)/lib/common_test/ebin/ct_cover_to_html.beam \
-	  --manifest "$(COVERAGE_DIR)/coverage.manifest" --max-per-line 5 \
-	  "$(COVERAGE_DIR)/html" "$(COVERAGE_DIR)"
-	@echo "LCOV tracefile:     $(COVERAGE_DIR)/coverage.info"
-	@echo "Attribution report: $(COVERAGE_DIR)/html/index.html"
+	@had=no; \
+	if [ -f "$(COVERAGE_DIR)/coverage.manifest" ]; then \
+	  $(ERL_TOP)/bin/escript $(ERL_TOP)/lib/common_test/ebin/ct_cover_to_lcov.beam \
+	    --manifest "$(COVERAGE_DIR)/coverage.manifest" \
+	    "$(COVERAGE_DIR)/coverage.info" "$(COVERAGE_DIR)" && \
+	  $(ERL_TOP)/bin/escript $(ERL_TOP)/lib/common_test/ebin/ct_cover_to_html.beam \
+	    --manifest "$(COVERAGE_DIR)/coverage.manifest" --max-per-line 5 \
+	    "$(COVERAGE_DIR)/html" "$(COVERAGE_DIR)"; \
+	  echo "BEAM line LCOV:      $(COVERAGE_DIR)/coverage.info"; \
+	  echo "Attribution report:  $(COVERAGE_DIR)/html/index.html"; \
+	  had=yes; \
+	fi; \
+	if [ -d "$(COVERAGE_DIR)/native" ]; then \
+	  $(ERL_TOP)/make/native_cov_to_lcov.sh "$(COVERAGE_DIR)/native" \
+	    "$(ERL_TOP)/bin/$(TARGET)/beam.clangcov.jit" \
+	    "$(COVERAGE_DIR)/native.info"; \
+	  if [ -f "$(COVERAGE_DIR)/native.info" ]; then \
+	    echo "Native C/JIT LCOV:   $(COVERAGE_DIR)/native.info"; had=yes; \
+	  fi; \
+	fi; \
+	if [ "$$had" = no ]; then \
+	  echo "No coverage data in $(COVERAGE_DIR). Run 'make test COVERAGE=yes' first."; \
+	  exit 1; \
+	fi
 
 docs: $(filter src java_src, $(SUB_DIRECTORIES))
 

--- a/make/clangcov_probe.escript
+++ b/make/clangcov_probe.escript
@@ -1,0 +1,56 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+%%
+%% Exercise the emulator broadly on a clangcov (clang source-based
+%% coverage) build and dump the native C + JIT-emitter coverage to the
+%% directory given as the only argument (erts_debug:coverage({dump,Dir})).
+%%
+%% Run on the clangcov emulator, e.g.:
+%%   ERL_AFLAGS="-emu_type clangcov" escript make/clangcov_probe.escript <dir>
+%%
+%% Used by the coverage workflow's native job to produce C/JIT coverage
+%% without the ct/release machinery (which cannot select -emu_type
+%% clangcov from a release that does not contain that emulator).
+main([Dir]) ->
+    io:format("build_type=~p~n", [erlang:system_info(build_type)]),
+    ok = filelib:ensure_path(Dir),
+    _ = exercise(),
+    case erts_debug:coverage({dump, Dir}) of
+        ok ->
+            io:format("dumped native coverage to ~ts~n", [Dir]);
+        Other ->
+            io:format(standard_error, "coverage dump failed: ~p~n", [Other]),
+            halt(1)
+    end.
+
+exercise() ->
+    %% Compiler + JIT: compile a spread of real stdlib sources (heavy on
+    %% the emitter and a large slice of the C runtime).
+    {ok, Cwd} = file:get_cwd(),
+    Src = filename:join([Cwd, "lib", "stdlib", "src"]),
+    Files = lists:sublist(filelib:wildcard(filename:join(Src, "*.erl")), 40),
+    _ = [try compile:file(F, [binary]) catch _:_ -> error end || F <- Files],
+    %% Terms, arithmetic and the common BIFs.
+    L = lists:seq(1, 200000),
+    _ = lists:sort(L ++ lists:reverse(L)),
+    _ = lists:foldl(fun(X, A) -> X + A end, 0, L),
+    M = maps:from_list([{X, X * 2} || X <- lists:seq(1, 20000)]),
+    _ = maps:fold(fun(_, V, A) -> V + A end, 0, M),
+    %% ETS (hash + tree paths).
+    Th = ets:new(h, [set]),
+    Tt = ets:new(t, [ordered_set]),
+    _ = [begin ets:insert(Th, {X, X}), ets:insert(Tt, {X, X}) end
+         || X <- lists:seq(1, 20000)],
+    _ = ets:select(Tt, [{{'$1', '$2'}, [{'>', '$1', 10000}], ['$2']}]),
+    %% Binaries + strings.
+    B = list_to_binary(lists:seq(0, 255)),
+    _ = [binary:match(B, <<X>>) || X <- lists:seq(0, 255)],
+    _ = << <<(X band 255):8>> || X <- lists:seq(1, 100000) >>,
+    _ = string:uppercase(lists:flatten(lists:duplicate(1000, "abc "))),
+    %% Processes + message passing.
+    Self = self(),
+    Pids = [spawn(fun() -> receive go -> Self ! done end end)
+            || _ <- lists:seq(1, 2000)],
+    _ = [P ! go || P <- Pids],
+    _ = [receive done -> ok end || _ <- Pids],
+    ok.

--- a/make/native_cov_to_lcov.sh
+++ b/make/native_cov_to_lcov.sh
@@ -39,14 +39,22 @@ OUT=${3:?missing output file argument}
 
 skip() { echo "native_cov_to_lcov: $1; skipping" >&2; exit 0; }
 
-# Locate the llvm tools: on PATH (typical Linux) or via xcrun (macOS).
+# Locate the llvm tools: unversioned on PATH (typical), via xcrun (macOS),
+# or a versioned pair (Ubuntu's `llvm` package often ships only llvm-cov-NN).
+PROFDATA=""; COV=""
 if command -v llvm-profdata >/dev/null 2>&1 && command -v llvm-cov >/dev/null 2>&1; then
     PROFDATA="llvm-profdata"; COV="llvm-cov"
 elif command -v xcrun >/dev/null 2>&1 && xcrun --find llvm-profdata >/dev/null 2>&1; then
     PROFDATA="xcrun llvm-profdata"; COV="xcrun llvm-cov"
 else
-    skip "llvm-profdata/llvm-cov not found"
+    for v in 22 21 20 19 18 17 16 15 14 13 12 11; do
+        if command -v "llvm-profdata-$v" >/dev/null 2>&1 \
+           && command -v "llvm-cov-$v" >/dev/null 2>&1; then
+            PROFDATA="llvm-profdata-$v"; COV="llvm-cov-$v"; break
+        fi
+    done
 fi
+[ -n "$PROFDATA" ] && [ -n "$COV" ] || skip "llvm-profdata/llvm-cov not found"
 
 # Resolve the emulator binary. Accept a file, a directory to search
 # recursively, or a missing path whose sibling beam.clangcov.* is used

--- a/make/native_cov_to_lcov.sh
+++ b/make/native_cov_to_lcov.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+#
+# %CopyrightBegin%
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright Ericsson AB 2026. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# %CopyrightEnd%
+#
+# Convert the clang source-based coverage *.profraw files dumped by
+# erts_debug:coverage/1 (via cth_coverage, into <dir>/native/) into a
+# single LCOV tracefile, using llvm-profdata + llvm-cov against the
+# clangcov emulator binary.
+#
+# Usage: native_cov_to_lcov.sh <native-dir> <emulator-binary> <out.info>
+#
+# Best-effort: if the llvm tools, the .profraw files, or the emulator
+# binary are missing it prints a note and exits 0 (so a report step that
+# calls it never fails a build that simply was not a clangcov run).
+
+set -eu
+
+NATIVE_DIR=${1:?usage: native_cov_to_lcov.sh <native-dir> <emu-binary> <out.info>}
+EMU=${2:?missing emulator binary argument}
+OUT=${3:?missing output file argument}
+
+skip() { echo "native_cov_to_lcov: $1; skipping" >&2; exit 0; }
+
+# Locate the llvm tools: on PATH (typical Linux) or via xcrun (macOS).
+if command -v llvm-profdata >/dev/null 2>&1 && command -v llvm-cov >/dev/null 2>&1; then
+    PROFDATA="llvm-profdata"; COV="llvm-cov"
+elif command -v xcrun >/dev/null 2>&1 && xcrun --find llvm-profdata >/dev/null 2>&1; then
+    PROFDATA="xcrun llvm-profdata"; COV="xcrun llvm-cov"
+else
+    skip "llvm-profdata/llvm-cov not found"
+fi
+
+# If the exact binary is absent, fall back to any beam.clangcov.* sibling
+# (the flavor suffix is .jit on JIT targets, .smp elsewhere).
+if [ ! -f "$EMU" ]; then
+    found=""
+    for cand in "$(dirname "$EMU")"/beam.clangcov.*; do
+        [ -f "$cand" ] && found="$cand" && break
+    done
+    [ -n "$found" ] || skip "clangcov emulator binary not found"
+    EMU="$found"
+fi
+
+# shellcheck disable=SC2086
+set -- "$NATIVE_DIR"/*.profraw
+if [ ! -e "$1" ]; then
+    skip "no .profraw files in $NATIVE_DIR"
+fi
+
+PROFDATA_FILE="$NATIVE_DIR/merged.profdata"
+$PROFDATA merge -sparse "$@" -o "$PROFDATA_FILE"
+$COV export -format=lcov -instr-profile="$PROFDATA_FILE" "$EMU" > "$OUT"
+
+echo "native_cov_to_lcov: wrote $OUT ($(grep -c '^SF:' "$OUT" 2>/dev/null || echo 0) files)"

--- a/make/native_cov_to_lcov.sh
+++ b/make/native_cov_to_lcov.sh
@@ -48,9 +48,14 @@ else
     skip "llvm-profdata/llvm-cov not found"
 fi
 
-# If the exact binary is absent, fall back to any beam.clangcov.* sibling
+# Resolve the emulator binary. Accept a file, a directory to search
+# recursively, or a missing path whose sibling beam.clangcov.* is used
 # (the flavor suffix is .jit on JIT targets, .smp elsewhere).
-if [ ! -f "$EMU" ]; then
+if [ -d "$EMU" ]; then
+    found=$(find "$EMU" -name 'beam.clangcov.*' -type f 2>/dev/null | head -n 1)
+    [ -n "$found" ] || skip "no clangcov emulator found under $EMU"
+    EMU="$found"
+elif [ ! -f "$EMU" ]; then
     found=""
     for cand in "$(dirname "$EMU")"/beam.clangcov.*; do
         [ -f "$cand" ] && found="$cand" && break

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -107,6 +107,16 @@ ifdef PRIMARY_BOOTSTRAP
 else
   ERL_COMPILE_FLAGS += +debug_info +warn_missing_doc_function +warn_missing_doc_callback +warn_missing_spec_documented
 endif
+# Native per-line coverage instrumentation for a coverage build (idea #78).
+# Off by default; enable with `make OTP_LINE_COVERAGE=yes`. +force_line_counters
+# makes modules line-counted from load (no runtime coverage mode needed), which
+# cth_coverage and code:get_coverage/reset_coverage rely on. Not applied to the
+# bootstrap compiler.
+ifndef PRIMARY_BOOTSTRAP
+ifeq ($(OTP_LINE_COVERAGE),yes)
+  ERL_COMPILE_FLAGS += +line_coverage +force_line_counters
+endif
+endif
 ifeq ($(ERL_DETERMINISTIC),yes)
   ERL_COMPILE_FLAGS += +deterministic
   YRL_FLAGS += +deterministic

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -48,7 +48,7 @@ CROSS_COMPILING = @CROSS_COMPILING@
 # ----------------------------------------------------
 DEFAULT_TARGETS =  opt debug release release_docs clean docs
 
-TYPES = opt debug lcnt valgrind asan gcov
+TYPES = opt debug lcnt valgrind asan gcov clangcov
 DEFAULT_TYPES = @DEFAULT_TYPES@
 FLAVORS = @FLAVORS@
 PRIMARY_FLAVOR= @PRIMARY_FLAVOR@

--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -33,7 +33,7 @@ include $(ERL_TOP)/make/target.mk
 
 .PHONY: valgrind asan test
 
-opt debug valgrind asan gcov gprof lcnt frmptr icount:
+opt debug valgrind asan gcov clangcov gprof lcnt frmptr icount:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile TYPE=$@
 
 emu jit:

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -284,6 +284,13 @@ if [ -n "${FLAVOR}" ]; then
     ERL_AFLAGS="${ERL_AFLAGS} -emu_flavor ${FLAVOR}"
 fi
 
+# Run the tests on a specific emulator type without changing the build
+# TYPE above (e.g. EMU_TYPE=clangcov to collect native C/JIT coverage on
+# a clangcov emulator). See $ERL_TOP/HOWTO/DEVELOPMENT.md.
+if [ -n "${EMU_TYPE}" ]; then
+    ERL_AFLAGS="${ERL_AFLAGS} -emu_type ${EMU_TYPE}"
+fi
+
 # Compile test server and configure
 if [ ! -f "$ERL_TOP/lib/common_test/test_server/variables.${TYPE}.${FLAVOR}" ]; then
     cd "$ERL_TOP/lib/common_test/test_server"

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -258,6 +258,20 @@ fi
 
 ARGS="${ARGS} ${EXTRA_ARGS}"
 
+# Native per-testcase line coverage (see $ERL_TOP/HOWTO/DEVELOPMENT.md).
+# COVERAGE=yes wires in the cth_coverage hook and a default output directory.
+# The system under test must have been built with `make OTP_LINE_COVERAGE=yes`
+# (only the system under test is instrumented, not the test suites).
+case "${COVERAGE}" in
+    yes|true|1)
+        ARGS="${ARGS} -ct_hooks cth_coverage"
+        CT_COVERAGE_DIR="${CT_COVERAGE_DIR:-$MAKE_TEST_DIR/coverage}"
+        export CT_COVERAGE_DIR
+        mkdir -p "$CT_COVERAGE_DIR"
+        print_highlighted_msg $LIGHT_CYAN "Coverage enabled: cth_coverage -> $CT_COVERAGE_DIR"
+        ;;
+esac
+
 if ([ -n "${TYPE}" ] || [ -n "${FLAVOR}" ]) && [ "${WSLcross}" = "true" ]; then
     print_highlighted_msg $RED "Setting TYPE or FLAVOR is not implemented yet for WSL"
     exit 1;


### PR DESCRIPTION
This pull request introduces comprehensive support for native per-line coverage instrumentation in the CI workflows for Erlang/OTP. It adds the ability to build and test OTP with line coverage enabled, aggregates and uploads detailed coverage reports, and ensures that coverage builds are fully isolated from normal CI caches and artifacts. The changes are primarily focused on the GitHub Actions workflows and Docker build process.

**Key changes:**

**1. Coverage Workflow Integration**
- Added a new workflow `.github/workflows/coverage.yaml` that builds OTP with native line coverage, runs tests with per-testcase coverage collection, aggregates the results into LCOV and HTML reports, and uploads these as artifacts. It also supports native C/JIT coverage via clang/llvm.

**2. Workflow and Action Inputs for Coverage**
- Introduced a `coverage` boolean input to `reusable-pack.yaml`, `reusable-test.yaml`, and the `build-base-image` action, enabling conditional activation of coverage instrumentation throughout the build and test pipelines. [[1]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R37-R41) [[2]](diffhunk://#diff-7c5987a904dd7e2458230012504fdb461f53b38578d543b94325fbce0bcaeacdR33-R37) [[3]](diffhunk://#diff-5b2d9846cbd51d697de28d86d5121761676ee10476ecc1d2cb10b19bba70aa8eR31-R33)

**3. Cache and Artifact Handling for Coverage**
- Modified caching logic in `reusable-pack.yaml` and `build-base-image` to ensure that instrumented builds do not use or pollute the normal pre-built caches, maintaining strict separation between coverage and non-coverage artifacts. [[1]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R128-R132) [[2]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R141) [[3]](diffhunk://#diff-5b2d9846cbd51d697de28d86d5121761676ee10476ecc1d2cb10b19bba70aa8eR73-R79)

**4. Docker Build and Environment for Coverage**
- Updated the Dockerfile and build scripts to accept an `OTP_LINE_COVERAGE` build argument, enabling OTP to be compiled with line coverage flags when requested. The test runner logic is also updated to correctly set up the environment and arguments for collecting per-testcase coverage. [[1]](diffhunk://#diff-4528e390c16a1f1caebc9b3e012842580d34dceb45a86878819f36b0d639765eR29-R34) [[2]](diffhunk://#diff-5b2d9846cbd51d697de28d86d5121761676ee10476ecc1d2cb10b19bba70aa8eR110-R118) [[3]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R195-R202) [[4]](diffhunk://#diff-7c5987a904dd7e2458230012504fdb461f53b38578d543b94325fbce0bcaeacdR66-R71) [[5]](diffhunk://#diff-7c5987a904dd7e2458230012504fdb461f53b38578d543b94325fbce0bcaeacdR89-R114)

**5. Test and Aggregation Enhancements**
- The test workflow now supports running with coverage enabled, collects and packages coverage data as part of test results, and the aggregation step merges per-testcase data into unified reports for further analysis and upload. [[1]](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fR1-R285) [[2]](diffhunk://#diff-7c5987a904dd7e2458230012504fdb461f53b38578d543b94325fbce0bcaeacdR89-R114)

These changes provide robust infrastructure for collecting, aggregating, and publishing native per-line coverage data for Erlang/OTP, supporting both BEAM and native code, while ensuring regular CI remains unaffected.

- Add new scheduled and manual coverage workflow with build, test, aggregation, and upload steps (.github/workflows/coverage.yaml)
- Add `coverage` input to reusable workflows and build-base-image action, and propagate through environment and build args (.github/workflows/reusable-pack.yaml, .github/workflows/reusable-test.yaml, .github/actions/build-base-image/action.yaml) [[1]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R37-R41) [[2]](diffhunk://#diff-7c5987a904dd7e2458230012504fdb461f53b38578d543b94325fbce0bcaeacdR33-R37) [[3]](diffhunk://#diff-5b2d9846cbd51d697de28d86d5121761676ee10476ecc1d2cb10b19bba70aa8eR31-R33)
- Skip pre-built cache steps for coverage builds to ensure isolation (.github/workflows/reusable-pack.yaml, .github/actions/build-base-image/action.yaml) [[1]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R128-R132) [[2]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R141) [[3]](diffhunk://#diff-5b2d9846cbd51d697de28d86d5121761676ee10476ecc1d2cb10b19bba70aa8eR73-R79)
- Update Dockerfile and build scripts to support `OTP_LINE_COVERAGE` build argument and environment (.github/dockerfiles/Dockerfile.64-bit, .github/actions/build-base-image/action.yaml, .github/workflows/reusable-pack.yaml) [[1]](diffhunk://#diff-4528e390c16a1f1caebc9b3e012842580d34dceb45a86878819f36b0d639765eR29-R34) [[2]](diffhunk://#diff-5b2d9846cbd51d697de28d86d5121761676ee10476ecc1d2cb10b19bba70aa8eR110-R118) [[3]](diffhunk://#diff-370ff2b826568843ac470a8a8a0c2e7d8a826cba1f134205ff1b0960747dd2b1R195-R202)
- Enhance test and aggregation logic to collect, merge, and upload per-testcase coverage data (.github/workflows/coverage.yaml, .github/workflows/reusable-test.yaml) [[1]](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fR1-R285) [[2]](diffhunk://#diff-7c5987a904dd7e2458230012504fdb461f53b38578d543b94325fbce0bcaeacdR89-R114)