### PR TITLE
inets: Improve httpd documentation to use types

### DIFF
--- a/lib/inets/doc/guides/hardening.md
+++ b/lib/inets/doc/guides/hardening.md
@@ -339,16 +339,14 @@ list. The default is:
 Review this list and remove modules you do not need:
 
 - **`mod_cgi`** and **`mod_actions`** - Enable CGI script execution.
-  Deprecated in OTP 29 and scheduled for removal in OTP 30. If you still
-  need CGI support, add them explicitly to your module list. CGI introduces a
-  large attack surface (arbitrary process execution, environment variable
-  injection).
+  Removed in OTP 30. CGI introduces a large attack surface (arbitrary process
+  execution, environment variable injection).
 
 - **`mod_dir`** - Enables directory listing. Remove it to prevent information
   disclosure about your file structure.
 
 - **`mod_esi`** - Enables Erlang Scripting Interface. If used, restrict it
-  with [`erl_script_alias`](`m:httpd#prop_esi_alias`) to a whitelist of allowed modules.
+  with [`erl_script_alias`](`m:mod_esi#prop_esi_alias`) to a whitelist of allowed modules.
 
 - **`mod_trace`** - Handles HTTP TRACE requests. TRACE can be exploited in
   cross-site tracing (XST) attacks. This module is not in the default list
@@ -364,17 +362,17 @@ A minimal module chain for a static file server:
 
 If using `mod_auth`:
 
-- **Avoid [`{auth_type, plain}`](`m:httpd#prop_auth_type`)** in production. It stores passwords in
+- **Avoid [`{auth_type, plain}`](`m:mod_auth#prop_auth_type`)** in production. It stores passwords in
   cleartext files. Prefer `dets` or `mnesia`.
 
-- **Place auth files outside `document_root`**. The [`auth_user_file`](`m:httpd#prop_auth_user_file`) and
-  [`auth_group_file`](`m:httpd#prop_auth_group_file`) must not be accessible via HTTP.
+- **Place auth files outside `document_root`**. The [`auth_user_file`](`m:mod_auth#prop_auth_user_file`) and
+  [`auth_group_file`](`m:mod_auth#prop_auth_group_file`) must not be accessible via HTTP.
 
-- **Set [`auth_access_password`](`m:httpd#prop_auth_access_passwd`)** to a strong value. When not set or set to
+- **Set [`auth_access_password`](`m:mod_auth#prop_auth_access_passwd`)** to a strong value. When not set or set to
   `"NoPassword"`, no password is required for the authentication management
   API.
 
-- **Use IP-based restrictions** ([`allow_from`](`m:httpd#prop_allow_from`), [`deny_from`](`m:httpd#prop_deny_from`)) as an additional
+- **Use IP-based restrictions** ([`allow_from`](`m:mod_auth#prop_allow_from`), [`deny_from`](`m:mod_auth#prop_deny_from`)) as an additional
   layer, not as the sole access control mechanism.
 
 > #### Warning {: .warning }
@@ -401,21 +399,21 @@ Enable `mod_security` to throttle authentication brute force attempts:
 ]}}
 ```
 
-- **[`data_file`](`m:httpd#prop_data_file`)** - Path to the persistent security
+- **[`data_file`](`m:mod_security#prop_data_file`)** - Path to the persistent security
   data file. Store this outside `document_root`. Required for `mod_security`
   to persist blocked-user state across server restarts.
 
-- **[`max_retries`](`m:httpd#prop_max_retries`)** - Maximum failed authentication
+- **[`max_retries`](`m:mod_security#prop_max_retries`)** - Maximum failed authentication
   attempts before the user is blocked. Default: `3`.
 
-- **[`block_time`](`m:httpd#prop_block_time`)** - Minutes a blocked user remains
+- **[`block_time`](`m:mod_security#prop_block_time`)** - Minutes a blocked user remains
   locked out. Default: `60`.
 
-- **[`fail_expire_time`](`m:httpd#prop_fail_exp_time`)** - Minutes before a
+- **[`fail_expire_time`](`m:mod_security#prop_fail_exp_time`)** - Minutes before a
   failed attempt is forgotten. If the user does not retry within this window,
   the failure counter resets. Default: `30`.
 
-- **[`auth_timeout`](`m:httpd#prop_auth_timeout`)** - Seconds a successful
+- **[`auth_timeout`](`m:mod_security#prop_auth_timeout`)** - Seconds a successful
   authentication is remembered. After expiry the user must re-authenticate.
   Default: `30`.
 
@@ -428,13 +426,13 @@ Enable `mod_security` to throttle authentication brute force attempts:
 For runtime inspection and manual blocking, see `m:mod_security`
 ([`list_blocked_users/1`](`mod_security:list_blocked_users/1`), [`block_user/5`](`mod_security:block_user/5`), [`unblock_user/4`](`mod_security:unblock_user/4`)).
 
-### CGI and ESI Execution
+### ESI Execution
 
-- **[`script_alias`](`m:httpd#prop_script_alias`)** maps URL paths to CGI script directories. Ensure the
+- **`script_alias`** maps URL paths to ESI script directories. Ensure the
   mapped directory contains only intended scripts and is not writable by the
   web server process.
 
-- **[`erl_script_alias`](`m:httpd#prop_esi_alias`)** controls which Erlang modules can be called via ESI.
+- **[`erl_script_alias`](`m:mod_esi#prop_esi_alias`)** controls which Erlang modules can be called via ESI.
   Always specify an explicit whitelist:
 
   ```erlang
@@ -443,10 +441,10 @@ For runtime inspection and manual blocking, see `m:mod_security`
 
   Never use a wildcard or overly broad module list.
 
-- **[`script_timeout`](`m:httpd#prop_script_timeout`)** and **[`erl_script_timeout`](`m:httpd#prop_esi_timeout`)** default to 15 seconds.
+- **`script_timeout`** and **[`erl_script_timeout`](`m:mod_esi#prop_esi_timeout`)** default to 15 seconds.
   Review whether this is appropriate for your use case.
 
-- **[`script_nocache`](`m:httpd#prop_script_nocache`)** and **[`erl_script_nocache`](`m:httpd#prop_esi_nocache`)** - When set to `true`, the
+- **`script_nocache`** and **[`erl_script_nocache`](`m:mod_esi#prop_esi_nocache`)** - When set to `true`, the
   server adds HTTP header fields preventing proxies from caching dynamic
   responses. Default: `false`. Enable these to prevent stale or sensitive
   dynamic content from being served from proxy caches.
@@ -455,8 +453,8 @@ For runtime inspection and manual blocking, see `m:mod_security`
 >
 > The `script_alias` path resolution can bypass `mod_auth` directory
 > protections depending on module ordering. Ensure `mod_auth` appears
-> before `mod_cgi` in the module chain, and test that authentication
-> is enforced on CGI paths.
+> before `mod_esi` in the module chain, and test that authentication
+> is enforced on ESI paths.
 
 ### Logging
 

--- a/lib/inets/doc/guides/http_server.md
+++ b/lib/inets/doc/guides/http_server.md
@@ -34,7 +34,6 @@ The server implements numerous features, such as:
 
 - Secure Sockets Layer (SSL)
 - Erlang Scripting Interface (ESI)
-- Common Gateway Interface (CGI)
 - User Authentication (using Mnesia, Dets or plain text database)
 - Common Logfile Format (with or without disk_log(3) support)
 - URL Aliasing
@@ -43,10 +42,10 @@ The server implements numerous features, such as:
 
 The configuration of the server is provided as an Erlang property list.
 
-As of `Inets` 5\.0 the HTTP server is an easy to start/stop and customize web
+The HTTP server is an easy to start/stop and customize web
 server providing the most basic web server functionality. Inets is designed for
 embedded systems and if you want a full-fledged web server there are other
-erlang open source alternatives.
+Erlang open source alternatives.
 
 Almost all server functionality has been implemented using an especially crafted
 server API, which is described in the Erlang Web Server API. This API can be
@@ -165,12 +164,6 @@ and cannot be the hostname that is allowed when putting in `bind_address`.
 `Inets` HTTP server provides two ways of creating dynamic web pages, each with
 its own advantages and disadvantages:
 
-- **_CGI scripts (deprecated)_** - Common Gateway Interface (CGI) scripts can be written in
-  any programming language. CGI scripts are standardized and supported by most
-  web servers. The drawback with CGI scripts is that they are resource-intensive
-  because of their design. CGI requires the server to fork a new OS process for
-  each executable it needs to start.
-
 - **_ESI-functions_** - Erlang Server Interface (ESI) functions provide a tight
   and efficient interface to the execution of Erlang functions. This interface,
   on the other hand, is `Inets` specific.
@@ -178,32 +171,7 @@ its own advantages and disadvantages:
 ### CGI Version 1.1, RFC 3875
 
 > #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-The module `mod_cgi` enables execution of
-[CGI scripts](http://www.ietf.org/rfc/rfc3875.txt) on the server. A file
-matching the definition of a ScriptAlias config directive is treated as a CGI
-script. A CGI script is executed by the server and its output is returned to the
-client.
-
-The CGI script response comprises a message header and a message body, separated
-by a blank line. The message header contains one or more header fields. The body
-can be empty.
-
-Example:
-
-```text
-"Content-Type:text/plain\nAccept-Ranges:none\n\nsome very
-	plain text"
-```
-
-The server interprets the message headers and most of them are transformed into
-HTTP headers and sent back to the client together with the message-body.
-
-Support for CGI-1.1 is implemented in accordance with
-[RFC 3875](http://www.ietf.org/rfc/rfc3875.txt).
+> `mod_cgi` and `mod_actions` are removed since OTP 39.
 
 ### ESI
 
@@ -318,26 +286,8 @@ of these modules is to be present in the module directive. Notice that there are
 some interaction dependencies to take into account, so the order of the modules
 cannot be random.
 
-### mod_actions - Filetype/Method-Based Script Execution
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-This module runs CGI scripts whenever a file of a certain type or HTTP method
-(see [RFC 1945](http://tools.ietf.org/html/rfc1945)) is requested.
-
-Uses the following Erlang Web Server API interaction data:
-
-- `real_name` \- from `m:mod_alias`.
-
-Exports the following Erlang Web Server API interaction data, if possible:
-
-- **`{new_request_uri, RequestURI}`** - An alternative `RequestURI` has been
-  generated.
-
 ### mod_alias - URL Aliasing
+{: #mod_alias }
 
 The `m:mod_alias` module makes it possible to map different parts of the host
 file system into the document tree, that is, creates aliases and redirections.
@@ -348,6 +298,7 @@ Exports the following Erlang Web Server API interaction data, if possible:
   `mod_alias:path/3`.
 
 ### mod_auth - User Authentication
+{: #mod_auth }
 
 The `m:mod_auth` module provides for basic user authentication using textual
 files, Dets databases as well as Mnesia databases.
@@ -411,16 +362,8 @@ the HTTP server. If they are placed in the directory which it protects, clients
 can download the tables. Only the Dets and Mnesia storage methods allow writing
 of dynamic user data to disk. `plain` is a read only method.
 
-### mod_cgi - CGI Scripts
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-This module handles invoking of CGI scripts.
-
 ### mod_dir - Directories
+{: #mod_dir }
 
 This module generates an HTML directory listing (Apache-style) if a client sends
 a request for a directory instead of a file. This module must be removed from
@@ -436,6 +379,7 @@ Exports the following Erlang Web Server API interaction data:
   a `MimeType`.
 
 ### mod_disk_log - Logging Using Disk_Log.
+{: #mod_disk_log }
 
 Standard logging using the "Common Logfile Format" and `m:disk_log`.
 
@@ -444,6 +388,7 @@ Uses the following Erlang Web Server API interaction data:
 - `remote_user` \- from `mod_auth`
 
 ### mod_esi - Erlang Server Interface
+{: #mod_esi }
 
 The `m:mod_esi` module implements the Erlang Server Interface (ESI) providing a
 tight and efficient interface to the execution of Erlang functions.
@@ -458,6 +403,7 @@ Exports the following Erlang web server API interaction data:
   a `MimeType`
 
 ### mod_get - Regular GET Requests
+{: #mod_get }
 
 This module is responsible for handling GET requests to regular files. GET
 requests for parts of files is handled by `mod_range`.
@@ -467,6 +413,7 @@ Uses the following Erlang web server API interaction data:
 - `real_name` \- from `m:mod_alias`
 
 ### mod_head - Regular HEAD Requests
+{: #mod_head }
 
 This module is responsible for handling HEAD requests to regular files. HEAD
 requests for dynamic content is handled by each module responsible for dynamic
@@ -477,6 +424,7 @@ Uses the following Erlang Web Server API interaction data:
 - `real_name` \- from `m:mod_alias`
 
 ### mod_log - Logging Using Text Files.
+{: #mod_log }
 
 Standard logging using the "Common Logfile Format" and text files.
 
@@ -485,6 +433,7 @@ Uses the following Erlang Web Server API interaction data:
 - `remote_user` \- from `mod_auth`
 
 ### mod_range - Requests with Range Headers
+{: #mod_range }
 
 This module responses to requests for one or many ranges of a file. This is
 especially useful when downloading large files, as a broken download can be
@@ -498,6 +447,7 @@ Uses the following Erlang Web Server API interaction data:
 - `real_name` \- from `m:mod_alias`
 
 ### mod_responsecontrol - Requests with If\* Headers
+{: #mod_responsecontrol }
 
 This module controls that the conditions in the requests are fulfilled. For
 example, a request can specify that the answer only is of interest if the
@@ -529,6 +479,7 @@ Exports the following Erlang Web Server API interaction data:
   must be treated as an ordinary get request.
 
 ### mod_security - Security Filter
+{: #mod_security }
 
 The `m:mod_security` module serves as a filter for authenticated requests
 handled in `m:mod_auth`. It provides a possibility to restrict users from access
@@ -541,6 +492,7 @@ blocked users or users who have been authenticated within a configurable amount
 of time.
 
 ### mod_trace - TRACE Request
+{: #mod_trace }
 
 `mod_trace` is responsible for handling of TRACE requests. Trace is a new
 request method in HTTP/1.1. The intended use of trace requests is for testing.

--- a/lib/inets/doc/guides/http_server.md
+++ b/lib/inets/doc/guides/http_server.md
@@ -34,7 +34,6 @@ The server implements numerous features, such as:
 
 - Secure Sockets Layer (SSL)
 - Erlang Scripting Interface (ESI)
-- Common Gateway Interface (CGI)
 - User Authentication (using Mnesia, Dets or plain text database)
 - Common Logfile Format (with or without disk_log(3) support)
 - URL Aliasing
@@ -43,10 +42,10 @@ The server implements numerous features, such as:
 
 The configuration of the server is provided as an Erlang property list.
 
-As of `Inets` 5\.0 the HTTP server is an easy to start/stop and customize web
+The HTTP server is an easy to start/stop and customize web
 server providing the most basic web server functionality. Inets is designed for
 embedded systems and if you want a full-fledged web server there are other
-erlang open source alternatives.
+Erlang open source alternatives.
 
 Almost all server functionality has been implemented using an especially crafted
 server API, which is described in the Erlang Web Server API. This API can be
@@ -165,12 +164,6 @@ and cannot be the hostname that is allowed when putting in `bind_address`.
 `Inets` HTTP server provides two ways of creating dynamic web pages, each with
 its own advantages and disadvantages:
 
-- **_CGI scripts (deprecated)_** - Common Gateway Interface (CGI) scripts can be written in
-  any programming language. CGI scripts are standardized and supported by most
-  web servers. The drawback with CGI scripts is that they are resource-intensive
-  because of their design. CGI requires the server to fork a new OS process for
-  each executable it needs to start.
-
 - **_ESI-functions_** - Erlang Server Interface (ESI) functions provide a tight
   and efficient interface to the execution of Erlang functions. This interface,
   on the other hand, is `Inets` specific.
@@ -178,32 +171,7 @@ its own advantages and disadvantages:
 ### CGI Version 1.1, RFC 3875
 
 > #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-The module `mod_cgi` enables execution of
-[CGI scripts](http://www.ietf.org/rfc/rfc3875.txt) on the server. A file
-matching the definition of a ScriptAlias config directive is treated as a CGI
-script. A CGI script is executed by the server and its output is returned to the
-client.
-
-The CGI script response comprises a message header and a message body, separated
-by a blank line. The message header contains one or more header fields. The body
-can be empty.
-
-Example:
-
-```text
-"Content-Type:text/plain\nAccept-Ranges:none\n\nsome very
-	plain text"
-```
-
-The server interprets the message headers and most of them are transformed into
-HTTP headers and sent back to the client together with the message-body.
-
-Support for CGI-1.1 is implemented in accordance with
-[RFC 3875](http://www.ietf.org/rfc/rfc3875.txt).
+> `mod_cgi` and `mod_actions` are removed since OTP 39.
 
 ### ESI
 
@@ -318,26 +286,8 @@ of these modules is to be present in the module directive. Notice that there are
 some interaction dependencies to take into account, so the order of the modules
 cannot be random.
 
-### mod_actions - Filetype/Method-Based Script Execution
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-This module runs CGI scripts whenever a file of a certain type or HTTP method
-(see [RFC 1945](http://tools.ietf.org/html/rfc1945)) is requested.
-
-Uses the following Erlang Web Server API interaction data:
-
-- `real_name` \- from `m:mod_alias`.
-
-Exports the following Erlang Web Server API interaction data, if possible:
-
-- **`{new_request_uri, RequestURI}`** - An alternative `RequestURI` has been
-  generated.
-
 ### mod_alias - URL Aliasing
+{: #mod_alias }
 
 The `m:mod_alias` module makes it possible to map different parts of the host
 file system into the document tree, that is, creates aliases and redirections.
@@ -348,6 +298,7 @@ Exports the following Erlang Web Server API interaction data, if possible:
   `mod_alias:path/3`.
 
 ### mod_auth - User Authentication
+{: #mod_auth }
 
 The `m:mod_auth` module provides for basic user authentication using textual
 files, Dets databases as well as Mnesia databases.
@@ -416,16 +367,8 @@ the HTTP server. If they are placed in the directory which it protects, clients
 can download the tables. Only the Dets and Mnesia storage methods allow writing
 of dynamic user data to disk. `plain` is a read only method.
 
-### mod_cgi - CGI Scripts
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-This module handles invoking of CGI scripts.
-
 ### mod_dir - Directories
+{: #mod_dir }
 
 This module generates an HTML directory listing (Apache-style) if a client sends
 a request for a directory instead of a file. This module must be removed from
@@ -441,6 +384,7 @@ Exports the following Erlang Web Server API interaction data:
   a `MimeType`.
 
 ### mod_disk_log - Logging Using Disk_Log.
+{: #mod_disk_log }
 
 Standard logging using the "Common Logfile Format" and `m:disk_log`.
 
@@ -449,6 +393,7 @@ Uses the following Erlang Web Server API interaction data:
 - `remote_user` \- from `mod_auth`
 
 ### mod_esi - Erlang Server Interface
+{: #mod_esi }
 
 The `m:mod_esi` module implements the Erlang Server Interface (ESI) providing a
 tight and efficient interface to the execution of Erlang functions.
@@ -463,6 +408,7 @@ Exports the following Erlang web server API interaction data:
   a `MimeType`
 
 ### mod_get - Regular GET Requests
+{: #mod_get }
 
 This module is responsible for handling GET requests to regular files. GET
 requests for parts of files is handled by `mod_range`.
@@ -472,6 +418,7 @@ Uses the following Erlang web server API interaction data:
 - `real_name` \- from `m:mod_alias`
 
 ### mod_head - Regular HEAD Requests
+{: #mod_head }
 
 This module is responsible for handling HEAD requests to regular files. HEAD
 requests for dynamic content is handled by each module responsible for dynamic
@@ -482,6 +429,7 @@ Uses the following Erlang Web Server API interaction data:
 - `real_name` \- from `m:mod_alias`
 
 ### mod_log - Logging Using Text Files.
+{: #mod_log }
 
 Standard logging using the "Common Logfile Format" and text files.
 
@@ -490,6 +438,7 @@ Uses the following Erlang Web Server API interaction data:
 - `remote_user` \- from `mod_auth`
 
 ### mod_range - Requests with Range Headers
+{: #mod_range }
 
 This module responses to requests for one or many ranges of a file. This is
 especially useful when downloading large files, as a broken download can be
@@ -503,6 +452,7 @@ Uses the following Erlang Web Server API interaction data:
 - `real_name` \- from `m:mod_alias`
 
 ### mod_responsecontrol - Requests with If\* Headers
+{: #mod_responsecontrol }
 
 This module controls that the conditions in the requests are fulfilled. For
 example, a request can specify that the answer only is of interest if the
@@ -534,6 +484,7 @@ Exports the following Erlang Web Server API interaction data:
   must be treated as an ordinary get request.
 
 ### mod_security - Security Filter
+{: #mod_security }
 
 The `m:mod_security` module serves as a filter for authenticated requests
 handled in `m:mod_auth`. It provides a possibility to restrict users from access
@@ -551,6 +502,7 @@ blocked users or users who have been authenticated within a configurable amount
 of time.
 
 ### mod_trace - TRACE Request
+{: #mod_trace }
 
 `mod_trace` is responsible for handling of TRACE requests. Trace is a new
 request method in HTTP/1.1. The intended use of trace requests is for testing.

--- a/lib/inets/doc/notes.md
+++ b/lib/inets/doc/notes.md
@@ -2627,7 +2627,7 @@ limitations under the License.
 
   `ossl` will work for as long as the ssl application supports it.
 
-  See the httpd [socket_type](`m:httpd#props_comm`) communication property or
+  See the httpd [socket_type](`m:httpd#prop_socket_type`) communication property or
   the httpc [request/4,5](`httpc:request/4`) function for more info.
 
   Own Id: OTP-9230
@@ -2636,7 +2636,7 @@ limitations under the License.
 
 ### Fixed Bugs and Malfunctions
 
-- \[httpd] Wrong [security property](`m:httpd#props_sec`) names used in
+- \[httpd] Wrong [security property](`t:mod_security:security_option/0`) names used in
   documentation.
 
   `security_data_file` used instead of `data_file`.
@@ -2762,7 +2762,7 @@ limitations under the License.
   instead.
 
   See the `http_option` option in the [request/4,5](`httpc:request/4`) or the
-  [socket-type](`m:httpd#props_comm`) section of the Communication properties
+  [socket_type](`m:httpd#prop_socket_type`) section of the Communication properties
   chapter for more info,
 
   Own Id: OTP-7907
@@ -2777,8 +2777,8 @@ limitations under the License.
 
 - \[httpd] - Improved mod_alias. Now able to do better URL rewrites.
 
-  See [URL aliasing properties](`m:httpd#props_alias`) and the
-  [CGI properties](`m:httpd#props_cgi`) section(s) for more info,
+  See [URL aliasing properties](`t:mod_alias:url_alias_option/0`) and the
+  CGI properties section(s) for more info,
 
   Own Id: OTP-8573
 
@@ -3103,8 +3103,7 @@ limitations under the License.
 
   Default is `inet6fb4` which emulates the behaviour of the previous version.
 
-  See the [Communication properties](`m:httpd#props_comm`) section for more
-  info.
+  See the [Communication properties](`t:httpd:communication_option/0`) section for more info.
 
   Own Id: OTP-8069
 

--- a/lib/inets/doc/notes.md
+++ b/lib/inets/doc/notes.md
@@ -2936,7 +2936,7 @@ limitations under the License.
 
   `ossl` will work for as long as the ssl application supports it.
 
-  See the httpd [socket_type](`m:httpd#props_comm`) communication property or
+  See the httpd [socket_type](`m:httpd#prop_socket_type`) communication property or
   the httpc [request/4,5](`httpc:request/4`) function for more info.
 
   Own Id: OTP-9230
@@ -2945,7 +2945,7 @@ limitations under the License.
 
 ### Fixed Bugs and Malfunctions
 
-- \[httpd] Wrong [security property](`m:httpd#props_sec`) names used in
+- \[httpd] Wrong [security property](`t:mod_security:security_option/0`) names used in
   documentation.
 
   `security_data_file` used instead of `data_file`.
@@ -3071,7 +3071,7 @@ limitations under the License.
   instead.
 
   See the `http_option` option in the [request/4,5](`httpc:request/4`) or the
-  [socket-type](`m:httpd#props_comm`) section of the Communication properties
+  [socket_type](`m:httpd#prop_socket_type`) section of the Communication properties
   chapter for more info,
 
   Own Id: OTP-7907
@@ -3086,8 +3086,8 @@ limitations under the License.
 
 - \[httpd] - Improved mod_alias. Now able to do better URL rewrites.
 
-  See [URL aliasing properties](`m:httpd#props_alias`) and the
-  [CGI properties](`m:httpd#props_cgi`) section(s) for more info,
+  See [URL aliasing properties](`t:mod_alias:url_alias_option/0`) and the
+  CGI properties section(s) for more info,
 
   Own Id: OTP-8573
 
@@ -3412,8 +3412,7 @@ limitations under the License.
 
   Default is `inet6fb4` which emulates the behaviour of the previous version.
 
-  See the [Communication properties](`m:httpd#props_comm`) section for more
-  info.
+  See the [Communication properties](`t:httpd:communication_option/0`) section for more info.
 
   Own Id: OTP-8069
 

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -29,41 +29,82 @@ An implementation of an HTTP 1.1 compliant web server, as defined in
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt). Provides web server start
 options, administrative functions, and an Erlang callback API.
 
-## Data types
-
-Type definitions that are used more than once in this module:
-
-`boolean() = true | false`
-
-`t:string/0` = list of ASCII characters
-
-`path() = string()` representing a file or a directory path
-
-`ip_address() = {N1,N2,N3,N4} % IPv4 | {K1,K2,K3,K4,K5,K6,K7,K8} % IPv6`
-
-`hostname() = string()` representing a host, for example, "foo.bar.com"
-
-`property() = atom()`
-
 ## HTTP server service start & stop
 
 A web server can be configured to start when starting the `Inets` application,
 or dynamically in runtime by calling the `Inets` application API
 `inets:start(httpd, ServiceConfig)` or `inets:start(httpd, ServiceConfig, How)`,
-see `m:inets`. The configuration options, also called properties, are as
+see `m:inets`.
+
+When the web server is started at application start time, the properties are to be part of the [inets applications sys config](`e:kernel:config.md`). If the web server is started dynamically at runtime, a file can still be specified but also the complete property list.
+
+The configuration options, also called properties, are as
 follows:
 
-[](){: #props_file }
+* [File Properties](`t:file_option/0`)
+* [Mandatory Properties](`t:mandatory_option/0`)
+* [Communication Properties](`t:communication_option/0`)
+* [Module Properties](`t:mod_option/0`)
+* [Limit Properties](`t:limit_option/0`)
+* [Admin Properties](`t:admin_option/0`)
 
-### File Properties
+Properties for specific modules:
 
-When the web server is started at application start time, the properties are to
-be fetched from a configuration file that can consist of a regular Erlang
-property list, that is, `[{Option, Value}]`, where `Option = property() `and
-`Value = term()`, followed by a full stop. If the web server is started
-dynamically at runtime, a file can still be specified but also the complete
-property list.
+* [URL Aliasing Properties](`t:mod_alias:url_alias_option/0`) - Requires `m:mod_alias`
+* [ESI Properties](`t:mod_esi:esi_option/0`) - Requires `m:mod_esi`
+* [Log Properties](`t:mod_log:log_option/0`) - Requires `m:mod_log`
+* [Disk Log Properties](`t:mod_disk_log:disk_log_option/0`) - Requires `m:mod_disk_log`
+* [Authentication Properties](`t:mod_auth:auth_option/0`) - Requires `m:mod_auth`
+* [Security Properties](`t:mod_security:security_option/0`) - Requires `m:mod_security`
 
+> #### Note {: .info }
+>
+> In OTP 30, `mod_cgi` and `mod_actions` were removed.
+
+### See also
+
+[RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), `m:inets`, `m:ssl`
+""".
+
+-compile([{nowarn_possibly_unsafe_function, {file, consult, 1}}]).
+
+-behaviour(inets_service).
+
+-include("httpd_internal.hrl").
+-include("../../include/httpd.hrl").
+
+%% Behavior callbacks
+-export([
+         start_standalone/1, 
+         start_service/1, 
+         stop_service/1, 
+         services/0, 
+         service_info/1
+        ]).
+
+%% API
+-export([
+         parse_query/1,
+         reload_config/2,
+         info/1,
+         info/2,
+         info/3,
+         info/4
+        ]).
+-export_type([socket_type/0, config_db/0, file_option/0]).
+
+%% Command line interface
+-export([start/1, serve/1]).
+
+-deprecated({parse_query, 1,
+            "use uri_string:dissect_query/1 instead"}).
+
+%%%========================================================================
+%%% Types
+%%%========================================================================
+-type property() :: atom().
+-type socket_type() :: ip_comm | ssl.
+-doc """
 - [](){: #prop_proplist_file } **`{proplist_file, path()}`**  
   If this property is defined, `Inets` expects to find all other properties
   defined in this file. The file must include all properties listed under
@@ -71,13 +112,13 @@ property list.
 
 > #### Note {: .info }
 >
-> Note support for legacy configuration file with Apache syntax is dropped in
+> Note support for legacy configuration file with Apache syntax was dropped in
 > OTP-23.
 
-[](){: #props_mand }
+""".
+-type file_option() :: {proplist_file, Path :: file:name_all()}.
 
-### Mandatory Properties
-
+-doc """
 - [](){: #prop_port } **`{port, integer()}`**  
   The port that the HTTP server listen to. If zero is specified as port, an
   arbitrary available port is picked and function `httpd:info/2` can be used to
@@ -90,70 +131,12 @@ property list.
 - [](){: #prop_doc_root } **`{document_root, path()}`**  
   Defines the top directory for the documents that are available on the HTTP
   server.
+""".
+-type mandatory_option() :: {port, non_neg_integer()}
+                | {server_root, Path :: file:name_all()}
+                | {document_root, Path :: file:name_all()}.
 
-[](){: #props_comm }
-
-### Communication Properties
-
-- [](){: #prop_bind_address } **`{bind_address, ip_address() | hostname() |
-  any}`**  
-  Default is `any`
-
-- [](){: #prop_server_name } **`{server_name, string()}`**  
-  The name of your server, normally a fully qualified domain name.
-
-  If not given, this defaults to `net_adm:localhost()`.
-
-- [](){: #profile } **`{profile, atom()}`**  
-  Used together with [`bind_address`](`m:httpd#prop_bind_address`) and
-  [`port`](`m:httpd#prop_port`) to uniquely identify a HTTP server. This can be
-  useful in a virtualized environment, where there can be more that one server
-  that has the same bind_address and port. If this property is not explicitly
-  set, it is assumed that the [`bind_address`](`m:httpd#prop_bind_address`) and
-  [`port`](`m:httpd#prop_port`) uniquely identifies the HTTP server.
-
-- [](){: #prop_socket_type } **`{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`**  
-  For `ip_comm` configuration options, see `gen_tcp:listen/2`, some options that
-  are used internally by httpd cannot be set.
-
-  For `SSL` configuration options, see `ssl:listen/2`.
-
-  Default is `ip_comm`.
-
-  > #### Note {: .info }
-  >
-  > OTP-25 deprecates the communication properties
-  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {essl, Config::proplist()}}`
-  > replacing it by
-  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`.
-
-- [](){: #prop_ipfamily } **`{ipfamily, inet | inet6}`**  
-  Default is `inet`, legacy option `inet6fb4` no longer makes sense and will be
-  translated to inet.
-
-- [](){: #prop_minimum_bytes_per_second } **`{minimum_bytes_per_second,
-  integer()}`**  
-  If given, sets a minimum of bytes per second value for connections.
-
-  If the value is unreached, the socket closes for that connection.
-
-  The option is good for reducing the risk of "slow DoS" attacks.
-
-[](){: #props_api_modules }
-
-### Erlang Web Server API Modules
-
-- [](){: #prop_modules } **`{modules, [atom()]}`**  
-  Defines which modules the HTTP server uses when handling requests. Default is
-  `[mod_alias, mod_auth, mod_esi, mod_dir, mod_get, mod_head, mod_log, mod_disk_log]`.
-  Notice that some `mod`\-modules are dependent on others, so the order cannot
-  be entirely arbitrary. See the [Inets Web Server Modules](http_server.md) in
-  the User's Guide for details.
-
-[](){: #props_limit }
-
-### Limit properties
-
+-doc """
 - [](){: #prop_customize } **`{customize, atom()}`**  
   A callback module to customize the inets HTTP servers behaviour see
   `m:httpd_custom_api`
@@ -200,11 +183,19 @@ property list.
   mod_esi callback. Note this is not supported for mod_cgi. Default is no limit
   e.i the whole body is delivered as one entity, which could be very memory
   consuming. `m:mod_esi`.
-
-[](){: #props_admin }
-
-### Administrative Properties
-
+""".
+-type limit_option() :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()}.
+-doc """
 - [](){: #prop_mime_types } **`{mime_types, [{MimeType, Extension}] | path()}`**  
   `MimeType = string()` and `Extension = string()`. Files delivered to the
   client are MIME typed according to RFC 1590. File suffixes are mapped to MIME
@@ -375,391 +366,78 @@ property list.
   ```
 
   This affects the error logs written by `mod_log` and `mod_disk_log`.
+""".
+-type admin_option() :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path :: file:name_all()}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact}.
+-doc """
+- [](){: #prop_bind_address } **`{bind_address, ip_address() | hostname() |
+  any}`**  
+  Default is `any`
 
-[](){: #props_alias }
+- [](){: #prop_server_name } **`{server_name, string()}`**  
+  The name of your server, normally a fully qualified domain name.
 
-### URL Aliasing Properties - Requires mod_alias
+  If not given, this defaults to `net_adm:localhost()`.
 
-- [](){: #prop_alias } **`{alias, {Alias, RealName}}`**  
-  `Alias = string()` and `RealName = string()`. `alias` allows documents to be
-  stored in the local file system instead of the `document_root` location. URLs
-  with a path beginning with url-path is mapped to local files beginning with
-  directory-filename, for example:
+- [](){: #profile } **`{profile, atom()}`**  
+  Used together with [`bind_address`](`m:httpd#prop_bind_address`) and
+  [`port`](`m:httpd#prop_port`) to uniquely identify a HTTP server. This can be
+  useful in a virtualized environment, where there can be more that one server
+  that has the same bind_address and port. If this property is not explicitly
+  set, it is assumed that the [`bind_address`](`m:httpd#prop_bind_address`) and
+  [`port`](`m:httpd#prop_port`) uniquely identifies the HTTP server.
 
-  ```erlang
-  {alias, {"/image", "/ftp/pub/image"}}
-  ```
+- [](){: #prop_socket_type } **`{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`**  
+  For `ip_comm` configuration options, see `gen_tcp:listen/2`, some options that
+  are used internally by httpd cannot be set.
 
-  Access to http://your.server.org/image/foo.gif would refer to the file
-  /ftp/pub/image/foo.gif.
+  For `SSL` configuration options, see `ssl:listen/2`.
 
-- [](){: #prop_re_write } **`{re_write, {Re, Replacement}}`**  
-  `Re = string()` and `Replacement = string()`. `re_write` allows documents to
-  be stored in the local file system instead of the `document_root` location.
-  URLs are rewritten by `re:replace/3` to produce a path in the local
-  file-system, for example:
-
-  ```erlang
-  {re_write, {"^/[~]([^/]+)(.*)$", "/home/\\1/public\\2"}}
-  ```
-
-  Access to http://your.server.org/~bob/foo.gif would refer to the file
-  /home/bob/public/foo.gif.
-
-- [](){: #prop_dir_idx } **`{directory_index, [string()]}`**  
-  `directory_index` specifies a list of resources to look for if a client
-  requests a directory using a `/` at the end of the directory name. `file`
-  depicts the name of a file in the directory. Several files can be given, in
-  which case the server returns the first it finds, for example:
-
-  ```erlang
-  {directory_index, ["index.html", "welcome.html"]}
-  ```
-
-  Access to http://your.server.org/docs/ would return
-  http://your.server.org/docs/index.html or
-  http://your.server.org/docs/welcome.html if index.html does not exist.
-
-[](){: #props_cgi }
-
-### CGI Properties - Requires mod_cgi
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-- [](){: #prop_script_alias } **`{script_alias, {Alias, RealName}}`**  
-  `Alias = string()` and `RealName = string()`. Have the same behavior as
-  property `alias`, except that they also mark the target directory as
-  containing CGI scripts. URLs with a path beginning with url-path are mapped to
-  scripts beginning with directory-filename, for example:
-
-  ```text
-  {script_alias, {"/cgi-bin/", "/web/cgi-bin/"}}
-  ```
-
-  Access to http://your.server.org/cgi-bin/foo would cause the server to run the
-  script /web/cgi-bin/foo.
+  Default is `ip_comm`.
 
   > #### Note {: .info }
   >
-  > When using `script_alias` with directory-based authentication
-  > (see [`directory`](`m:httpd#prop_dri`)), ensure that authentication
-  > rules reference the actual filesystem path (RealName), not the URL path (Alias).
-  > The server correctly resolves script_alias paths for authentication checks.
-  >
-
-- [](){: #prop_script_re_write } **`{script_re_write, {Re, Replacement}}`**  
-  `Re = string()` and `Replacement = string()`. Have the same behavior as
-  property `re_write`, except that they also mark the target directory as
-  containing CGI scripts. URLs with a path beginning with url-path are mapped to
-  scripts beginning with directory-filename, for example:
-
-  ```text
-  {script_re_write, {"^/cgi-bin/(\\d+)/", "/web/\\1/cgi-bin/"}}
-  ```
-
-  Access to http://your.server.org/cgi-bin/17/foo would cause the server to run
-  the script /web/17/cgi-bin/foo.
-
-- [](){: #prop_script_nocache } **`{script_nocache, boolean()}`**  
-  If `script_nocache` is set to `true`, the HTTP server by default adds the
-  header fields necessary to prevent proxies from caching the page. Generally
-  this is preferred. Default to `false`.
-
-- [](){: #prop_script_timeout } **`{script_timeout, integer()}`**  
-  The time in seconds the web server waits between each chunk of data from the
-  script. If the CGI script does not deliver any data before the timeout, the
-  connection to the client is closed. Default is `15`.
-
-- [](){: #prop_action } **`{action, {MimeType, CgiScript}}`** - requires `mod_actions`  
-  `MimeType = string()` and `CgiScript = string()`. `action` adds an action
-  activating a CGI script whenever a file of a certain MIME type is requested.
-  It propagates the URL and file path of the requested document using the
-  standard CGI PATH_INFO and PATH_TRANSLATED environment variables.
-
-  Example:
-
-  ```text
-  {action, {"text/plain", "/cgi-bin/log_and_deliver_text"}}
-  ```
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-- [](){: #prop_script } **`{script, {Method, CgiScript}}`** - requires `mod_actions`  
-  `Method = string()` and `CgiScript = string()`. `script` adds an action
-  activating a CGI script whenever a file is requested using a certain HTTP
-  method. The method is either GET or POST, as defined in
-  [RFC 1945](http://www.ietf.org/rfc/rfc1945.txt). It propagates the URL and
-  file path of the requested document using the standard CGI PATH_INFO and
-  PATH_TRANSLATED environment variables.
-
-  Example:
-
-  ```erlang
-  {script, {"PUT", "/cgi-bin/put"}}
-  ```
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-[](){: #props_esi }
-
-### ESI Properties - Requires mod_esi
-
-- [](){: #prop_esi_alias } **`{erl_script_alias, {URLPath, [AllowedModule]}}`**  
-  `URLPath = string()` and `AllowedModule = atom()`. `erl_script_alias` marks
-  all URLs matching url-path as erl scheme scripts. A matching URL is mapped
-  into a specific module and function, for example:
-
-  ```erlang
-  {erl_script_alias, {"/cgi-bin/example", [httpd_example]}}
-  ```
-
-  A request to http://your.server.org/cgi-bin/example/httpd_example:yahoo would
-  refer to httpd_example:yahoo/3 or, if that does not exist,
-  httpd_example:yahoo/2 and http://your.server.org/cgi-bin/example/other:yahoo
-  would not be allowed to execute.
-
-- [](){: #prop_esi_nocache } **`{erl_script_nocache, boolean()}`**  
-  If `erl_script_nocache` is set to `true`, the server adds HTTP header fields
-  preventing proxies from caching the page. This is generally a good idea for
-  dynamic content, as the content often varies between each request. Default is
-  `false`.
-
-- [](){: #prop_esi_timeout } **`{erl_script_timeout, integer()}`**  
-  If `erl_script_timeout` sets the time in seconds the server waits between each
-  chunk of data to be delivered through `mod_esi:deliver/2`. Default is `15`.
-  This is only relevant for scripts that use the erl scheme.
-
-[](){: #props_log }
-
-### Log Properties - Requires mod_log
-
-- [](){: #prop_elog } **`{error_log, path()}`**  
-  Defines the filename of the error log file to be used to log server errors. If
-  the filename does not begin with a slash (/), it is assumed to be relative to
-  the `server_root`.
-
-- [](){: #prop_slog } **`{security_log, path()}`**  
-  Defines the filename of the access log file to be used to log security events.
-  If the filename does not begin with a slash (/), it is assumed to be relative
-  to the `server_root`.
-
-- [](){: #prop_tlog } **`{transfer_log, path()}`**  
-  Defines the filename of the access log file to be used to log incoming
-  requests. If the filename does not begin with a slash (/), it is assumed to be
-  relative to the `server_root`.
-
-[](){: #props_dlog }
-
-### Disk Log Properties - Requires mod_disk_log
-
-- [](){: #prop_dlog_format } **`{disk_log_format, internal | external}`**  
-  Defines the file format of the log files. See `disk_log` for details. If the
-  internal file format is used, the log file is repaired after a crash. When a
-  log file is repaired, data can disappear. When the external file format is
-  used, `httpd` does not start if the log file is broken. Default is `external`.
-
-- [](){: #prop_edlog } **`{error_disk_log, path()}`**  
-  Defines the filename of the (`m:disk_log`) error log file to be used to log
-  server errors. If the filename does not begin with a slash (/), it is assumed
-  to be relative to the `server_root`.
-
-- [](){: #prop_edlog_size } **`{error_disk_log_size, {MaxBytes, MaxFiles}}`**  
-  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
-  the (`m:disk_log`) error log file. This file is of type wrap log and max bytes
-  is written to each file and max files is used before the first file is
-  truncated and reused.
-
-- [](){: #prop_sdlog } **`{security_disk_log, path()}`**  
-  Defines the filename of the (`m:disk_log`) access log file logging incoming
-  security events, that is, authenticated requests. If the filename does not
-  begin with a slash (/), it is assumed to be relative to the `server_root`.
-
-- [](){: #prop_sdlog_size } **`{security_disk_log_size, {MaxBytes, MaxFiles}}`**  
-  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
-  the `m:disk_log` access log file. This file is of type wrap log and max bytes
-  is written to each file and max files is used before the first file is
-  truncated and reused.
-
-- [](){: #prop_tdlog } **`{transfer_disk_log, path()}`**  
-  Defines the filename of the (`m:disk_log`) access log file logging incoming
-  requests. If the filename does not begin with a slash (/), it is assumed to be
-  relative to the `server_root`.
-
-- [](){: #prop_tdlog_size } **`{transfer_disk_log_size, {MaxBytes, MaxFiles}}`**  
-  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
-  the `m:disk_log` access log file. This file is of type wrap log and max bytes
-  is written to each file and max files is used before the first file is
-  truncated and reused.
-
-[](){: #props_auth }
-
-### Authentication Properties - Requires mod_auth
-
-[](){: #prop_dri }
-
-```erlang
-{directory, {path(), [{property(), term()}]}}
-```
-
-[](){: #props_dir }
-
-The properties for directories are as follows:
-
-- [](){: #prop_allow_from } **`{allow_from, all | [RegxpHostString]}`**  
-  Defines a set of hosts to be granted access to a given directory, for example:
-
-  ```erlang
-  {allow_from, ["123.34.56.11", "150.100.23"]}
-  ```
-
-  The host `123.34.56.11` and all machines on the `150.100.23` subnet are
-  allowed access.
-
-- [](){: #prop_deny_from } **`{deny_from, all | [RegxpHostString]}`**  
-  Defines a set of hosts to be denied access to a given directory, for example:
-
-  ```text
-  {deny_from, ["123.34.56.11", "150.100.23"]}
-  ```
-
-  The host `123.34.56.11` and all machines on the `150.100.23` subnet are not
-  allowed access.
-
-- [](){: #prop_auth_type } **`{auth_type, plain | dets | mnesia}`**  
-  Sets the type of authentication database that is used for the directory. The
-  key difference between the different methods is that dynamic data can be saved
-  when Mnesia and Dets are used.
-
-- [](){: #prop_auth_user_file } **`{auth_user_file, path()}`**  
-  Sets the name of a file containing the list of users and passwords for user
-  authentication. The filename can be either absolute or relative to the
-  `server_root`. If using the plain storage method, this file is a plain text
-  file where each line contains a username followed by a colon, followed by the
-  non-encrypted password. If usernames are duplicated, the behavior is
-  undefined.
-
-  Example:
-
-  ```text
-  ragnar:s7Xxv7
-  edward:wwjau8
-  ```
-
-  If the Dets storage method is used, the user database is maintained by Dets
-  and must not be edited by hand. Use the API functions in module `mod_auth` to
-  create/edit the user database. This directive is ignored if the Mnesia storage
-  method is used. For security reasons, ensure that `auth_user_file` is stored
-  outside the document tree of the web server. If it is placed in the directory
-  that it protects, clients can download it.
-
-- [](){: #prop_auth_group_file } **`{auth_group_file, path()}`**  
-  Sets the name of a file containing the list of user groups for user
-  authentication. The filename can be either absolute or relative to the
-  `server_root`. If the plain storage method is used, the group file is a plain
-  text file, where each line contains a group name followed by a colon, followed
-  by the members usernames separated by spaces.
-
-  Example:
-
-  ```text
-  group1: bob joe ante
-  ```
-
-  If the Dets storage method is used, the group database is maintained by Dets
-  and must not be edited by hand. Use the API for module `mod_auth` to
-  create/edit the group database. This directive is ignored if the Mnesia
-  storage method is used. For security reasons, ensure that the
-  `auth_group_file` is stored outside the document tree of the web server. If it
-  is placed in the directory that it protects, clients can download it.
-
-- [](){: #prop_auth_name } **`{auth_name, string()}`**  
-  Sets the name of the authorization realm (auth-domain) for a directory. This
-  string informs the client about which username and password to use.
-
-- [](){: #prop_auth_access_passwd } **`{auth_access_password, string()}`**  
-  If set to other than `"NoPassword"`, the password is required for all API calls.
-  If the password is set to `"DummyPassword"`, the password must be changed before
-  any other API calls. To secure the authenticating data, the password must be
-  changed after the web server is started. Otherwise it is written in clear text
-  in the configuration file.
-
-- [](){: #prop_req_user } **`{require_user, [string()]}`**  
-  Defines users to grant access to a given directory using a secret password.
-
-- [](){: #prop_req_grp } **`{require_group, [string()]}`**  
-  Defines users to grant access to a given directory using a secret password.
-
-[](){: #props_sec }
-
-### Security Properties - Requires mod_security
-
-[](){: #prop_sec_dir }
-
-```erlang
-{security_directory, {path(), [{property(), term()}]}}
-```
-
-[](){: #props_sdir }
-
-The properties for the security directories are as follows:
-
-- [](){: #prop_data_file } **`{data_file, path()}`**  
-  Name of the security data file. The filename can either be absolute or
-  relative to the `server_root`. This file is used to store persistent data for
-  module `mod_security`.
-
-- [](){: #prop_max_retries } **`{max_retries, integer()}`**  
-  Specifies the maximum number of attempts to authenticate a user before the
-  user is blocked out. If a user successfully authenticates while blocked, the
-  user receives a 403 (Forbidden) response from the server. If the user makes a
-  failed attempt while blocked, the server returns 401 (Unauthorized), for
-  security reasons. Default is `3`. Can be set to infinity.
-
-- [](){: #prop_block_time } **`{block_time, integer()}`**  
-  Specifies the number of minutes a user is blocked. After this time has passed,
-  the user automatically regains access. Default is `60`.
-
-- [](){: #prop_fail_exp_time } **`{fail_expire_time, integer()}`**  
-  Specifies the number of minutes a failed user authentication is remembered. If
-  a user authenticates after this time has passed, the previous failed
-  authentications are forgotten. Default is `30`.
-
-- [](){: #prop_auth_timeout } **`{auth_timeout, integer()}`**  
-  Specifies the number of seconds a successful user authentication is
-  remembered. After this time has passed, the authentication is no longer
-  reported. Default is `30`.
-
-## Web server API data types
-
-The Erlang web server API data types are as follows:
-
-```erlang
-ModData = #mod{}
-
--record(mod, {
-    data = [],
-    socket_type = ip_comm,
-    socket,
-    config_db,
-    method,
-    absolute_uri,
-    request_uri,
-    http_version,
-    request_line,
-    parsed_header = [],
-    entity_body,
-    connection
-}).
-```
+  > OTP-25 deprecates the communication properties
+  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {essl, Config::proplist()}}`
+  > replacing it by
+  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`.
+
+- [](){: #prop_ipfamily } **`{ipfamily, inet | inet6}`**  
+  Default is `inet`, legacy option `inet6fb4` no longer makes sense and will be
+  translated to inet.
+
+- [](){: #prop_minimum_bytes_per_second } **`{minimum_bytes_per_second,
+  integer()}`**  
+  If given, sets a minimum of bytes per second value for connections.
+
+  If the value is unreached, the socket closes for that connection.
+
+  The option is good for reducing the risk of "slow DoS" attacks.
+""".
+-type communication_option() :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {server_name, string()}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()}.
+-doc """
+- [](){: #prop_modules } **`{modules, [atom()]}`**  
+  Defines which modules the HTTP server uses when handling requests. Default is
+  `[mod_alias, mod_auth, mod_esi, mod_dir, mod_get, mod_head, mod_log, mod_disk_log]`.
+  Notice that some `mod`\-modules are dependent on others, so the order cannot
+  be entirely arbitrary. See the [Inets Web Server Modules](http_server.md) in
+  the User's Guide for details.
+""".
+-type mod_option() :: {modules, atom()}.
+
+-doc """
+The Erlang web server API data type `t:mod_data/0` is a record of type `mod` that is used to propagate data between modules.
 
 To access the record in your callback-module use:
 
@@ -783,7 +461,7 @@ The fields of record `mod` have the following meaning:
   ETS table. Depicted `config_db()` in function type declarations.
 
 - **`method`** - Type `"GET" | "POST" | "HEAD" | "TRACE"`, that is, the HTTP
-  method.
+  method as a string.
 
 - **`absolute_uri`** - If the request is an HTTP/1.1 request, the URI can be in
   the absolute URI format. In that case, `httpd` saves the absolute URI in this
@@ -817,55 +495,42 @@ The fields of record `mod` have the following meaning:
   client is a persistent connection and is not closed when the request is
   served.
 
-### See also
-
-[RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), `m:inets`, `m:ssl`
 """.
+-type mod_data() ::
+    #mod{ data :: interaction_data(),
+          socket_type :: socket_type(),
+          socket :: gen_tcp:socket() | ssl:sslsocket(),
+          config_db :: config_db(),
+          method :: string(),
+          absolute_uri :: string() | undefined,
+          request_uri :: string(),
+          http_version :: string(),
+          request_line :: string(),
+          parsed_header :: [{HeaderKey :: string(), HeaderValue :: string()}],
+          entity_body :: iolist() | undefined,
+          connection :: boolean()
+}.
 
--compile([{nowarn_possibly_unsafe_function, {file, consult, 1}}]).
+-doc """
+The config file directives stored as key-value tuples in an ETS table, as
+described in the [Inets User's Guide](http_server.md). This is the value held in
+the `config_db` field of `t:mod_data/0`.
+""".
+-type config_db() :: ets:table().
 
--behaviour(inets_service).
-
--include("httpd_internal.hrl").
-
-%% Behavior callbacks
--export([
-	 start_standalone/1, 
-	 start_service/1, 
-	 stop_service/1, 
-	 services/0, 
-	 service_info/1
-	]).
-
-%% API
--export([
-         parse_query/1,
-         reload_config/2,
-         info/1,
-         info/2,
-         info/3,
-         info/4
-        ]).
--export_type([socket_type/0]).
-
-%% Command line interface
--export([start/1, serve/1]).
-
--deprecated({parse_query, 1,
-            "use uri_string:dissect_query/1 instead"}).
-
-%%%========================================================================
-%%% Types
-%%%========================================================================
--type property() :: atom().
--type socket_type() :: ip_comm | ssl.
+-doc """
+Data used to propagate information between callback modules while a single
+request is processed. This is the value held in the `data` field of
+`t:mod_data/0`.
+""".
+-type interaction_data() :: [{InteractionKey :: term(), InteractionValue :: term()}].
 
 %%%========================================================================
 %%% Callbacks
 %%%========================================================================
 -doc """
 When a valid request reaches `httpd`, it calls [`do/1`](`c:do/1`) in each
-module, defined by the configuration option of `Module`. The function can
+module, defined by the configuration option of `t:mod_option/0`. The function can
 generate data for other modules or a response that can be sent back to the
 client.
 
@@ -898,9 +563,7 @@ the client by closing the connection.
 >
 
 """.
--doc(#{group => <<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>}).
--callback do(ModData) -> {proceed, OldData} | {proceed, NewData} | {break, NewData} | done when
-      ModData :: [{data,NewData} | {'Body', Body} | {'Head',Head}],
+-callback do(ModData :: mod_data()) -> {proceed, OldData} | {proceed, NewData} | {break, NewData} | done when
       OldData :: list(),
       NewData :: [{response, NewDataCompatFormat}] | [{response, NewDataFormat}],
       NewDataCompatFormat :: {StatusCode, Body},
@@ -908,10 +571,16 @@ the client by closing the connection.
       StatusCode :: integer(),
       Size :: non_neg_integer(),
       Body :: iolist() | nobody | {Fun, FunArg},
-      Head :: [HeaderOption] | {Key, Value},
+      Head :: [HeaderOption],
       HeaderOption :: {Option, Value} | {code, StatusCode},
-      Option :: accept_ranges | allow,
-      Key :: atom() | string(),
+      Option :: accept_ranges | allow
+              | cache_control | content_MD5
+              | content_encoding | content_language
+              | content_length | content_location
+              | content_range | content_type | date
+              | etag | expires | last_modified
+              | location | pragma | retry_after
+              | server | trailer | transfer_encoding,
       Value :: string(),
       FunArg :: [term()],
       Fun :: fun((FunArg) -> sent | close | Body).
@@ -921,9 +590,8 @@ When `httpd` is shut down, it tries to execute [`remove/1`](`c:remove/1`) in
 each Erlang web server callback module. The programmer can use this function to
 clean up resources created in the store function.
 """.
--doc(#{group => <<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>}).
 -callback remove(ConfigDB) -> ok | {error, Reason} when
-      ConfigDB :: ets:tid(), Reason :: term().
+      ConfigDB :: config_db(), Reason :: term().
 
 -doc """
 Checks the validity of the configuration options before saving them in the
@@ -933,7 +601,6 @@ resolve possible dependencies among configuration options by changing the value
 of the option. This function only needs clauses for the options implemented by
 this particular callback module.
 """.
--doc(#{group => <<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>}).
 -callback store({Option, Value}, Config) ->
     {ok, {Option, NewValue}} | {error, Reason} when
       Option :: property(),
@@ -995,41 +662,16 @@ reload_config(ConfigFile, Mode) ->
 -doc(#{equiv => info/2}).
 -spec info(Pid) -> HttpInformation when
       Pid :: pid(),
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer()}
-                   | {max_body_size, integer()}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Pid) when is_pid(Pid) ->
     info(Pid, []).
 
@@ -1048,78 +690,29 @@ server.
 -spec info(Pid, Properties) -> HttpInformation  when
       Pid     :: pid(),
       Properties :: [atom()],
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
       ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer()}
-                   | {max_body_size, integer()}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact};
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option();
           (Address, Port) -> HttpInformation when
       Address :: inet:ip_address(),
-      Port    :: integer(),
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      Port :: non_neg_integer(),
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer()}
-                   | {max_body_size, integer()}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Pid, Properties) when is_pid(Pid) andalso is_list(Properties) ->
     {ok, ServiceInfo} = service_info(Pid), 
     Address = proplists:get_value(bind_address, ServiceInfo),
@@ -1140,80 +733,30 @@ info(Address, Port) when is_integer(Port) ->
       Address :: inet:ip_address() | any,
       Port    :: integer(),
       Profile :: atom(),
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer()}
-                   | {max_body_size, integer()}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact};
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option();
           (Address, Port, Properties) -> HttpInformation when
       Address :: inet:ip_address() | any,
       Port    :: integer(),
       Properties :: [atom()],
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer()}
-                   | {max_body_size, integer()}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Address, Port, Profile) when is_integer(Port), is_atom(Profile) ->
     httpd_conf:get_config(Address, Port, Profile);
 
@@ -1237,41 +780,16 @@ options of the server.
       Port    :: integer(),
       Profile :: atom(),
       Properties :: [atom()],
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer()}
-                   | {max_body_size, integer()}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Address, Port, Profile, Properties) when is_integer(Port) andalso
 					      is_atom(Profile) andalso is_list(Properties) ->    
     httpd_conf:get_config(Address, Port, Profile, Properties).

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -29,41 +29,82 @@ An implementation of an HTTP 1.1 compliant web server, as defined in
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt). Provides web server start
 options, administrative functions, and an Erlang callback API.
 
-## Data types
-
-Type definitions that are used more than once in this module:
-
-`boolean() = true | false`
-
-`t:string/0` = list of ASCII characters
-
-`path() = string()` representing a file or a directory path
-
-`ip_address() = {N1,N2,N3,N4} % IPv4 | {K1,K2,K3,K4,K5,K6,K7,K8} % IPv6`
-
-`hostname() = string()` representing a host, for example, "foo.bar.com"
-
-`property() = atom()`
-
 ## HTTP server service start & stop
 
 A web server can be configured to start when starting the `Inets` application,
 or dynamically in runtime by calling the `Inets` application API
 `inets:start(httpd, ServiceConfig)` or `inets:start(httpd, ServiceConfig, How)`,
-see `m:inets`. The configuration options, also called properties, are as
+see `m:inets`.
+
+When the web server is started at application start time, the properties are to be part of the [inets applications sys config](`e:kernel:config.md`). If the web server is started dynamically at runtime, a file can still be specified but also the complete property list.
+
+The configuration options, also called properties, are as
 follows:
 
-[](){: #props_file }
+* [File Properties](`t:file_option/0`)
+* [Mandatory Properties](`t:mandatory_option/0`)
+* [Communication Properties](`t:communication_option/0`)
+* [Module Properties](`t:mod_option/0`)
+* [Limit Properties](`t:limit_option/0`)
+* [Admin Properties](`t:admin_option/0`)
 
-### File Properties
+Properties for specific modules:
 
-When the web server is started at application start time, the properties are to
-be fetched from a configuration file that can consist of a regular Erlang
-property list, that is, `[{Option, Value}]`, where `Option = property() `and
-`Value = term()`, followed by a full stop. If the web server is started
-dynamically at runtime, a file can still be specified but also the complete
-property list.
+* [URL Aliasing Properties](`t:mod_alias:url_alias_option/0`) - Requires `m:mod_alias`
+* [ESI Properties](`t:mod_esi:esi_option/0`) - Requires `m:mod_esi`
+* [Log Properties](`t:mod_log:log_option/0`) - Requires `m:mod_log`
+* [Disk Log Properties](`t:mod_disk_log:disk_log_option/0`) - Requires `m:mod_disk_log`
+* [Authentication Properties](`t:mod_auth:auth_option/0`) - Requires `m:mod_auth`
+* [Security Properties](`t:mod_security:security_option/0`) - Requires `m:mod_security`
 
+> #### Note {: .info }
+>
+> In OTP 30, `mod_cgi` and `mod_actions` were removed.
+
+### See also
+
+[RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), `m:inets`, `m:ssl`
+""".
+
+-compile([{nowarn_possibly_unsafe_function, {file, consult, 1}}]).
+
+-behaviour(inets_service).
+
+-include("httpd_internal.hrl").
+-include("../../include/httpd.hrl").
+
+%% Behavior callbacks
+-export([
+         start_standalone/1, 
+         start_service/1, 
+         stop_service/1, 
+         services/0, 
+         service_info/1
+        ]).
+
+%% API
+-export([
+         parse_query/1,
+         reload_config/2,
+         info/1,
+         info/2,
+         info/3,
+         info/4
+        ]).
+-export_type([socket_type/0, config_db/0, file_option/0]).
+
+%% Command line interface
+-export([start/1, serve/1]).
+
+-deprecated({parse_query, 1,
+            "use uri_string:dissect_query/1 instead"}).
+
+%%%========================================================================
+%%% Types
+%%%========================================================================
+-type property() :: atom().
+-type socket_type() :: ip_comm | ssl.
+-doc """
 - [](){: #prop_proplist_file } **`{proplist_file, path()}`**  
   If this property is defined, `Inets` expects to find all other properties
   defined in this file. The file must include all properties listed under
@@ -71,13 +112,13 @@ property list.
 
 > #### Note {: .info }
 >
-> Note support for legacy configuration file with Apache syntax is dropped in
+> Note support for legacy configuration file with Apache syntax was dropped in
 > OTP-23.
 
-[](){: #props_mand }
+""".
+-type file_option() :: {proplist_file, Path :: file:name_all()}.
 
-### Mandatory Properties
-
+-doc """
 - [](){: #prop_port } **`{port, integer()}`**  
   The port that the HTTP server listen to. If zero is specified as port, an
   arbitrary available port is picked and function `httpd:info/2` can be used to
@@ -90,70 +131,12 @@ property list.
 - [](){: #prop_doc_root } **`{document_root, path()}`**  
   Defines the top directory for the documents that are available on the HTTP
   server.
+""".
+-type mandatory_option() :: {port, non_neg_integer()}
+                | {server_root, Path :: file:name_all()}
+                | {document_root, Path :: file:name_all()}.
 
-[](){: #props_comm }
-
-### Communication Properties
-
-- [](){: #prop_bind_address } **`{bind_address, ip_address() | hostname() |
-  any}`**  
-  Default is `any`
-
-- [](){: #prop_server_name } **`{server_name, string()}`**  
-  The name of your server, normally a fully qualified domain name.
-
-  If not given, this defaults to `net_adm:localhost()`.
-
-- [](){: #profile } **`{profile, atom()}`**  
-  Used together with [`bind_address`](`m:httpd#prop_bind_address`) and
-  [`port`](`m:httpd#prop_port`) to uniquely identify a HTTP server. This can be
-  useful in a virtualized environment, where there can be more that one server
-  that has the same bind_address and port. If this property is not explicitly
-  set, it is assumed that the [`bind_address`](`m:httpd#prop_bind_address`) and
-  [`port`](`m:httpd#prop_port`) uniquely identifies the HTTP server.
-
-- [](){: #prop_socket_type } **`{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`**  
-  For `ip_comm` configuration options, see `gen_tcp:listen/2`, some options that
-  are used internally by httpd cannot be set.
-
-  For `SSL` configuration options, see `ssl:listen/2`.
-
-  Default is `ip_comm`.
-
-  > #### Note {: .info }
-  >
-  > OTP-25 deprecates the communication properties
-  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {essl, Config::proplist()}}`
-  > replacing it by
-  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`.
-
-- [](){: #prop_ipfamily } **`{ipfamily, inet | inet6}`**  
-  Default is `inet`, legacy option `inet6fb4` no longer makes sense and will be
-  translated to inet.
-
-- [](){: #prop_minimum_bytes_per_second } **`{minimum_bytes_per_second,
-  integer()}`**  
-  If given, sets a minimum of bytes per second value for connections.
-
-  If the value is unreached, the socket closes for that connection.
-
-  The option is good for reducing the risk of "slow DoS" attacks.
-
-[](){: #props_api_modules }
-
-### Erlang Web Server API Modules
-
-- [](){: #prop_modules } **`{modules, [atom()]}`**  
-  Defines which modules the HTTP server uses when handling requests. Default is
-  `[mod_alias, mod_auth, mod_esi, mod_dir, mod_get, mod_head, mod_log, mod_disk_log]`.
-  Notice that some `mod`\-modules are dependent on others, so the order cannot
-  be entirely arbitrary. See the [Inets Web Server Modules](http_server.md) in
-  the User's Guide for details.
-
-[](){: #props_limit }
-
-### Limit properties
-
+-doc """
 - [](){: #prop_customize } **`{customize, atom()}`**  
   A callback module to customize the inets HTTP servers behaviour see
   `m:httpd_custom_api`
@@ -197,22 +180,31 @@ property list.
 - [](){: #prop_max_uri } **`{max_uri_size, integer() | nolimit}`**
   Limits the size of the HTTP request URI. Default is no limit.
 
-- [](){: #prop_max_keep_alive_req } **`{max_keep_alive_request, integer()}`**  
+- [](){: #prop_max_keep_alive_req } **`{max_keep_alive_request, pos_integer()}`**  
   The number of requests that a client can do on one connection. When the server
   has responded to the number of requests defined by `max_keep_alive_requests`,
   the server closes the connection. The server closes it even if there are
   queued request. Default is no limit.
 
-- [](){: #max_client_body_chunk } **`{max_client_body_chunk, integer()}`**  
+- [](){: #max_client_body_chunk } **`{max_client_body_chunk, pos_integer()}`**  
   Enforces chunking of a HTTP PUT or POST body data to be delivered to the
   mod_esi callback. Note this is not supported for mod_cgi. Default is no limit
   e.i the whole body is delivered as one entity, which could be very memory
   consuming. `m:mod_esi`.
-
-[](){: #props_admin }
-
-### Administrative Properties
-
+""".
+-type limit_option() :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, pos_integer() | infinity}
+                   | {max_body_size, pos_integer() | nolimit}
+                   | {max_clients, pos_integer()}
+                   | {max_header_size, pos_integer()}
+                   | {max_content_length, pos_integer()}
+                   | {max_uri_size, pos_integer() | nolimit}
+                   | {max_keep_alive_request, pos_integer()}
+                   | {max_client_body_chunk, pos_integer()}
+                   | {request_timeout, pos_integer() | infinity}.
+-doc """
 - [](){: #prop_mime_types } **`{mime_types, [{MimeType, Extension}] | path()}`**  
   `MimeType = string()` and `Extension = string()`. Files delivered to the
   client are MIME typed according to RFC 1590. File suffixes are mapped to MIME
@@ -383,391 +375,78 @@ property list.
   ```
 
   This affects the error logs written by `mod_log` and `mod_disk_log`.
+""".
+-type admin_option() :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path :: file:name_all()}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact}.
+-doc """
+- [](){: #prop_bind_address } **`{bind_address, ip_address() | hostname() |
+  any}`**  
+  Default is `any`
 
-[](){: #props_alias }
+- [](){: #prop_server_name } **`{server_name, string()}`**  
+  The name of your server, normally a fully qualified domain name.
 
-### URL Aliasing Properties - Requires mod_alias
+  If not given, this defaults to `net_adm:localhost()`.
 
-- [](){: #prop_alias } **`{alias, {Alias, RealName}}`**  
-  `Alias = string()` and `RealName = string()`. `alias` allows documents to be
-  stored in the local file system instead of the `document_root` location. URLs
-  with a path beginning with url-path is mapped to local files beginning with
-  directory-filename, for example:
+- [](){: #profile } **`{profile, atom()}`**  
+  Used together with [`bind_address`](`m:httpd#prop_bind_address`) and
+  [`port`](`m:httpd#prop_port`) to uniquely identify a HTTP server. This can be
+  useful in a virtualized environment, where there can be more that one server
+  that has the same bind_address and port. If this property is not explicitly
+  set, it is assumed that the [`bind_address`](`m:httpd#prop_bind_address`) and
+  [`port`](`m:httpd#prop_port`) uniquely identifies the HTTP server.
 
-  ```erlang
-  {alias, {"/image", "/ftp/pub/image"}}
-  ```
+- [](){: #prop_socket_type } **`{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`**  
+  For `ip_comm` configuration options, see `gen_tcp:listen/2`, some options that
+  are used internally by httpd cannot be set.
 
-  Access to http://your.server.org/image/foo.gif would refer to the file
-  /ftp/pub/image/foo.gif.
+  For `SSL` configuration options, see `ssl:listen/2`.
 
-- [](){: #prop_re_write } **`{re_write, {Re, Replacement}}`**  
-  `Re = string()` and `Replacement = string()`. `re_write` allows documents to
-  be stored in the local file system instead of the `document_root` location.
-  URLs are rewritten by `re:replace/3` to produce a path in the local
-  file-system, for example:
-
-  ```erlang
-  {re_write, {"^/[~]([^/]+)(.*)$", "/home/\\1/public\\2"}}
-  ```
-
-  Access to http://your.server.org/~bob/foo.gif would refer to the file
-  /home/bob/public/foo.gif.
-
-- [](){: #prop_dir_idx } **`{directory_index, [string()]}`**  
-  `directory_index` specifies a list of resources to look for if a client
-  requests a directory using a `/` at the end of the directory name. `file`
-  depicts the name of a file in the directory. Several files can be given, in
-  which case the server returns the first it finds, for example:
-
-  ```erlang
-  {directory_index, ["index.html", "welcome.html"]}
-  ```
-
-  Access to http://your.server.org/docs/ would return
-  http://your.server.org/docs/index.html or
-  http://your.server.org/docs/welcome.html if index.html does not exist.
-
-[](){: #props_cgi }
-
-### CGI Properties - Requires mod_cgi
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-- [](){: #prop_script_alias } **`{script_alias, {Alias, RealName}}`**  
-  `Alias = string()` and `RealName = string()`. Have the same behavior as
-  property `alias`, except that they also mark the target directory as
-  containing CGI scripts. URLs with a path beginning with url-path are mapped to
-  scripts beginning with directory-filename, for example:
-
-  ```text
-  {script_alias, {"/cgi-bin/", "/web/cgi-bin/"}}
-  ```
-
-  Access to http://your.server.org/cgi-bin/foo would cause the server to run the
-  script /web/cgi-bin/foo.
+  Default is `ip_comm`.
 
   > #### Note {: .info }
   >
-  > When using `script_alias` with directory-based authentication
-  > (see [`directory`](`m:httpd#prop_dri`)), ensure that authentication
-  > rules reference the actual filesystem path (RealName), not the URL path (Alias).
-  > The server correctly resolves script_alias paths for authentication checks.
-  >
-
-- [](){: #prop_script_re_write } **`{script_re_write, {Re, Replacement}}`**  
-  `Re = string()` and `Replacement = string()`. Have the same behavior as
-  property `re_write`, except that they also mark the target directory as
-  containing CGI scripts. URLs with a path beginning with url-path are mapped to
-  scripts beginning with directory-filename, for example:
-
-  ```text
-  {script_re_write, {"^/cgi-bin/(\\d+)/", "/web/\\1/cgi-bin/"}}
-  ```
-
-  Access to http://your.server.org/cgi-bin/17/foo would cause the server to run
-  the script /web/17/cgi-bin/foo.
-
-- [](){: #prop_script_nocache } **`{script_nocache, boolean()}`**  
-  If `script_nocache` is set to `true`, the HTTP server by default adds the
-  header fields necessary to prevent proxies from caching the page. Generally
-  this is preferred. Default to `false`.
-
-- [](){: #prop_script_timeout } **`{script_timeout, integer()}`**  
-  The time in seconds the web server waits between each chunk of data from the
-  script. If the CGI script does not deliver any data before the timeout, the
-  connection to the client is closed. Default is `15`.
-
-- [](){: #prop_action } **`{action, {MimeType, CgiScript}}`** - requires `mod_actions`  
-  `MimeType = string()` and `CgiScript = string()`. `action` adds an action
-  activating a CGI script whenever a file of a certain MIME type is requested.
-  It propagates the URL and file path of the requested document using the
-  standard CGI PATH_INFO and PATH_TRANSLATED environment variables.
-
-  Example:
-
-  ```text
-  {action, {"text/plain", "/cgi-bin/log_and_deliver_text"}}
-  ```
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-- [](){: #prop_script } **`{script, {Method, CgiScript}}`** - requires `mod_actions`  
-  `Method = string()` and `CgiScript = string()`. `script` adds an action
-  activating a CGI script whenever a file is requested using a certain HTTP
-  method. The method is either GET or POST, as defined in
-  [RFC 1945](http://www.ietf.org/rfc/rfc1945.txt). It propagates the URL and
-  file path of the requested document using the standard CGI PATH_INFO and
-  PATH_TRANSLATED environment variables.
-
-  Example:
-
-  ```erlang
-  {script, {"PUT", "/cgi-bin/put"}}
-  ```
-
-> #### Note {: .info }
-> `mod_cgi` and `mod_actions` are deprecated since OTP 29 and will be removed in OTP 30.
-> Use `mod_esi` instead for dynamic page generation.
->
-
-[](){: #props_esi }
-
-### ESI Properties - Requires mod_esi
-
-- [](){: #prop_esi_alias } **`{erl_script_alias, {URLPath, [AllowedModule]}}`**  
-  `URLPath = string()` and `AllowedModule = atom()`. `erl_script_alias` marks
-  all URLs matching url-path as erl scheme scripts. A matching URL is mapped
-  into a specific module and function, for example:
-
-  ```erlang
-  {erl_script_alias, {"/cgi-bin/example", [httpd_example]}}
-  ```
-
-  A request to http://your.server.org/cgi-bin/example/httpd_example:yahoo would
-  refer to httpd_example:yahoo/3 or, if that does not exist,
-  httpd_example:yahoo/2 and http://your.server.org/cgi-bin/example/other:yahoo
-  would not be allowed to execute.
-
-- [](){: #prop_esi_nocache } **`{erl_script_nocache, boolean()}`**  
-  If `erl_script_nocache` is set to `true`, the server adds HTTP header fields
-  preventing proxies from caching the page. This is generally a good idea for
-  dynamic content, as the content often varies between each request. Default is
-  `false`.
-
-- [](){: #prop_esi_timeout } **`{erl_script_timeout, integer()}`**  
-  If `erl_script_timeout` sets the time in seconds the server waits between each
-  chunk of data to be delivered through `mod_esi:deliver/2`. Default is `15`.
-  This is only relevant for scripts that use the erl scheme.
-
-[](){: #props_log }
-
-### Log Properties - Requires mod_log
-
-- [](){: #prop_elog } **`{error_log, path()}`**  
-  Defines the filename of the error log file to be used to log server errors. If
-  the filename does not begin with a slash (/), it is assumed to be relative to
-  the `server_root`.
-
-- [](){: #prop_slog } **`{security_log, path()}`**  
-  Defines the filename of the access log file to be used to log security events.
-  If the filename does not begin with a slash (/), it is assumed to be relative
-  to the `server_root`.
-
-- [](){: #prop_tlog } **`{transfer_log, path()}`**  
-  Defines the filename of the access log file to be used to log incoming
-  requests. If the filename does not begin with a slash (/), it is assumed to be
-  relative to the `server_root`.
-
-[](){: #props_dlog }
-
-### Disk Log Properties - Requires mod_disk_log
-
-- [](){: #prop_dlog_format } **`{disk_log_format, internal | external}`**  
-  Defines the file format of the log files. See `disk_log` for details. If the
-  internal file format is used, the log file is repaired after a crash. When a
-  log file is repaired, data can disappear. When the external file format is
-  used, `httpd` does not start if the log file is broken. Default is `external`.
-
-- [](){: #prop_edlog } **`{error_disk_log, path()}`**  
-  Defines the filename of the (`m:disk_log`) error log file to be used to log
-  server errors. If the filename does not begin with a slash (/), it is assumed
-  to be relative to the `server_root`.
-
-- [](){: #prop_edlog_size } **`{error_disk_log_size, {MaxBytes, MaxFiles}}`**  
-  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
-  the (`m:disk_log`) error log file. This file is of type wrap log and max bytes
-  is written to each file and max files is used before the first file is
-  truncated and reused.
-
-- [](){: #prop_sdlog } **`{security_disk_log, path()}`**  
-  Defines the filename of the (`m:disk_log`) access log file logging incoming
-  security events, that is, authenticated requests. If the filename does not
-  begin with a slash (/), it is assumed to be relative to the `server_root`.
-
-- [](){: #prop_sdlog_size } **`{security_disk_log_size, {MaxBytes, MaxFiles}}`**  
-  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
-  the `m:disk_log` access log file. This file is of type wrap log and max bytes
-  is written to each file and max files is used before the first file is
-  truncated and reused.
-
-- [](){: #prop_tdlog } **`{transfer_disk_log, path()}`**  
-  Defines the filename of the (`m:disk_log`) access log file logging incoming
-  requests. If the filename does not begin with a slash (/), it is assumed to be
-  relative to the `server_root`.
-
-- [](){: #prop_tdlog_size } **`{transfer_disk_log_size, {MaxBytes, MaxFiles}}`**  
-  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
-  the `m:disk_log` access log file. This file is of type wrap log and max bytes
-  is written to each file and max files is used before the first file is
-  truncated and reused.
-
-[](){: #props_auth }
-
-### Authentication Properties - Requires mod_auth
-
-[](){: #prop_dri }
-
-```erlang
-{directory, {path(), [{property(), term()}]}}
-```
-
-[](){: #props_dir }
-
-The properties for directories are as follows:
-
-- [](){: #prop_allow_from } **`{allow_from, all | [RegxpHostString]}`**  
-  Defines a set of hosts to be granted access to a given directory, for example:
-
-  ```erlang
-  {allow_from, ["123.34.56.11", "150.100.23"]}
-  ```
-
-  The host `123.34.56.11` and all machines on the `150.100.23` subnet are
-  allowed access.
-
-- [](){: #prop_deny_from } **`{deny_from, all | [RegxpHostString]}`**  
-  Defines a set of hosts to be denied access to a given directory, for example:
-
-  ```text
-  {deny_from, ["123.34.56.11", "150.100.23"]}
-  ```
-
-  The host `123.34.56.11` and all machines on the `150.100.23` subnet are not
-  allowed access.
-
-- [](){: #prop_auth_type } **`{auth_type, plain | dets | mnesia}`**  
-  Sets the type of authentication database that is used for the directory. The
-  key difference between the different methods is that dynamic data can be saved
-  when Mnesia and Dets are used.
-
-- [](){: #prop_auth_user_file } **`{auth_user_file, path()}`**  
-  Sets the name of a file containing the list of users and passwords for user
-  authentication. The filename can be either absolute or relative to the
-  `server_root`. If using the plain storage method, this file is a plain text
-  file where each line contains a username followed by a colon, followed by the
-  non-encrypted password. If usernames are duplicated, the behavior is
-  undefined.
-
-  Example:
-
-  ```text
-  ragnar:s7Xxv7
-  edward:wwjau8
-  ```
-
-  If the Dets storage method is used, the user database is maintained by Dets
-  and must not be edited by hand. Use the API functions in module `mod_auth` to
-  create/edit the user database. This directive is ignored if the Mnesia storage
-  method is used. For security reasons, ensure that `auth_user_file` is stored
-  outside the document tree of the web server. If it is placed in the directory
-  that it protects, clients can download it.
-
-- [](){: #prop_auth_group_file } **`{auth_group_file, path()}`**  
-  Sets the name of a file containing the list of user groups for user
-  authentication. The filename can be either absolute or relative to the
-  `server_root`. If the plain storage method is used, the group file is a plain
-  text file, where each line contains a group name followed by a colon, followed
-  by the members usernames separated by spaces.
-
-  Example:
-
-  ```text
-  group1: bob joe ante
-  ```
-
-  If the Dets storage method is used, the group database is maintained by Dets
-  and must not be edited by hand. Use the API for module `mod_auth` to
-  create/edit the group database. This directive is ignored if the Mnesia
-  storage method is used. For security reasons, ensure that the
-  `auth_group_file` is stored outside the document tree of the web server. If it
-  is placed in the directory that it protects, clients can download it.
-
-- [](){: #prop_auth_name } **`{auth_name, string()}`**  
-  Sets the name of the authorization realm (auth-domain) for a directory. This
-  string informs the client about which username and password to use.
-
-- [](){: #prop_auth_access_passwd } **`{auth_access_password, string()}`**  
-  If set to other than `"NoPassword"`, the password is required for all API calls.
-  If the password is set to `"DummyPassword"`, the password must be changed before
-  any other API calls. To secure the authenticating data, the password must be
-  changed after the web server is started. Otherwise it is written in clear text
-  in the configuration file.
-
-- [](){: #prop_req_user } **`{require_user, [string()]}`**  
-  Defines users to grant access to a given directory using a secret password.
-
-- [](){: #prop_req_grp } **`{require_group, [string()]}`**  
-  Defines users to grant access to a given directory using a secret password.
-
-[](){: #props_sec }
-
-### Security Properties - Requires mod_security
-
-[](){: #prop_sec_dir }
-
-```erlang
-{security_directory, {path(), [{property(), term()}]}}
-```
-
-[](){: #props_sdir }
-
-The properties for the security directories are as follows:
-
-- [](){: #prop_data_file } **`{data_file, path()}`**  
-  Name of the security data file. The filename can either be absolute or
-  relative to the `server_root`. This file is used to store persistent data for
-  module `mod_security`.
-
-- [](){: #prop_max_retries } **`{max_retries, integer()}`**  
-  Specifies the maximum number of attempts to authenticate a user before the
-  user is blocked out. If a user successfully authenticates while blocked, the
-  user receives a 403 (Forbidden) response from the server. If the user makes a
-  failed attempt while blocked, the server returns 401 (Unauthorized), for
-  security reasons. Default is `3`. Can be set to infinity.
-
-- [](){: #prop_block_time } **`{block_time, integer()}`**  
-  Specifies the number of minutes a user is blocked. After this time has passed,
-  the user automatically regains access. Default is `60`.
-
-- [](){: #prop_fail_exp_time } **`{fail_expire_time, integer()}`**  
-  Specifies the number of minutes a failed user authentication is remembered. If
-  a user authenticates after this time has passed, the previous failed
-  authentications are forgotten. Default is `30`.
-
-- [](){: #prop_auth_timeout } **`{auth_timeout, integer()}`**  
-  Specifies the number of seconds a successful user authentication is
-  remembered. After this time has passed, the authentication is no longer
-  reported. Default is `30`.
-
-## Web server API data types
-
-The Erlang web server API data types are as follows:
-
-```erlang
-ModData = #mod{}
-
--record(mod, {
-    data = [],
-    socket_type = ip_comm,
-    socket,
-    config_db,
-    method,
-    absolute_uri,
-    request_uri,
-    http_version,
-    request_line,
-    parsed_header = [],
-    entity_body,
-    connection
-}).
-```
+  > OTP-25 deprecates the communication properties
+  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {essl, Config::proplist()}}`
+  > replacing it by
+  > `{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}`.
+
+- [](){: #prop_ipfamily } **`{ipfamily, inet | inet6}`**  
+  Default is `inet`, legacy option `inet6fb4` no longer makes sense and will be
+  translated to inet.
+
+- [](){: #prop_minimum_bytes_per_second } **`{minimum_bytes_per_second,
+  integer()}`**  
+  If given, sets a minimum of bytes per second value for connections.
+
+  If the value is unreached, the socket closes for that connection.
+
+  The option is good for reducing the risk of "slow DoS" attacks.
+""".
+-type communication_option() :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {server_name, string()}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()}.
+-doc """
+- [](){: #prop_modules } **`{modules, [atom()]}`**  
+  Defines which modules the HTTP server uses when handling requests. Default is
+  `[mod_alias, mod_auth, mod_esi, mod_dir, mod_get, mod_head, mod_log, mod_disk_log]`.
+  Notice that some `mod`\-modules are dependent on others, so the order cannot
+  be entirely arbitrary. See the [Inets Web Server Modules](http_server.md) in
+  the User's Guide for details.
+""".
+-type mod_option() :: {modules, atom()}.
+
+-doc """
+The Erlang web server API data type `t:mod_data/0` is a record of type `mod` that is used to propagate data between modules.
 
 To access the record in your callback-module use:
 
@@ -791,7 +470,7 @@ The fields of record `mod` have the following meaning:
   ETS table. Depicted `config_db()` in function type declarations.
 
 - **`method`** - Type `"GET" | "POST" | "HEAD" | "TRACE"`, that is, the HTTP
-  method.
+  method as a string.
 
 - **`absolute_uri`** - If the request is an HTTP/1.1 request, the URI can be in
   the absolute URI format. In that case, `httpd` saves the absolute URI in this
@@ -825,55 +504,42 @@ The fields of record `mod` have the following meaning:
   client is a persistent connection and is not closed when the request is
   served.
 
-### See also
-
-[RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), `m:inets`, `m:ssl`
 """.
+-type mod_data() ::
+    #mod{ data :: interaction_data(),
+          socket_type :: socket_type(),
+          socket :: gen_tcp:socket() | ssl:sslsocket(),
+          config_db :: config_db(),
+          method :: string(),
+          absolute_uri :: string() | undefined,
+          request_uri :: string(),
+          http_version :: string(),
+          request_line :: string(),
+          parsed_header :: [{HeaderKey :: string(), HeaderValue :: string()}],
+          entity_body :: iolist() | undefined,
+          connection :: boolean()
+}.
 
--compile([{nowarn_possibly_unsafe_function, {file, consult, 1}}]).
+-doc """
+The config file directives stored as key-value tuples in an ETS table, as
+described in the [Inets User's Guide](http_server.md). This is the value held in
+the `config_db` field of `t:mod_data/0`.
+""".
+-type config_db() :: ets:table().
 
--behaviour(inets_service).
-
--include("httpd_internal.hrl").
-
-%% Behavior callbacks
--export([
-	 start_standalone/1, 
-	 start_service/1, 
-	 stop_service/1, 
-	 services/0, 
-	 service_info/1
-	]).
-
-%% API
--export([
-         parse_query/1,
-         reload_config/2,
-         info/1,
-         info/2,
-         info/3,
-         info/4
-        ]).
--export_type([socket_type/0]).
-
-%% Command line interface
--export([start/1, serve/1]).
-
--deprecated({parse_query, 1,
-            "use uri_string:dissect_query/1 instead"}).
-
-%%%========================================================================
-%%% Types
-%%%========================================================================
--type property() :: atom().
--type socket_type() :: ip_comm | ssl.
+-doc """
+Data used to propagate information between callback modules while a single
+request is processed. This is the value held in the `data` field of
+`t:mod_data/0`.
+""".
+-type interaction_data() :: [{InteractionKey :: term(), InteractionValue :: term()}].
 
 %%%========================================================================
 %%% Callbacks
 %%%========================================================================
 -doc """
 When a valid request reaches `httpd`, it calls [`do/1`](`c:do/1`) in each
-module, defined by the configuration option of `Module`. The function can
+module, defined by the configuration option of `t:mod_option/0`. The function can
 generate data for other modules or a response that can be sent back to the
 client.
 
@@ -906,9 +572,7 @@ the client by closing the connection.
 >
 
 """.
--doc(#{group => <<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>}).
--callback do(ModData) -> {proceed, OldData} | {proceed, NewData} | {break, NewData} | done when
-      ModData :: [{data,NewData} | {'Body', Body} | {'Head',Head}],
+-callback do(ModData :: mod_data()) -> {proceed, OldData} | {proceed, NewData} | {break, NewData} | done when
       OldData :: list(),
       NewData :: [{response, NewDataCompatFormat}] | [{response, NewDataFormat}],
       NewDataCompatFormat :: {StatusCode, Body},
@@ -916,10 +580,16 @@ the client by closing the connection.
       StatusCode :: integer(),
       Size :: non_neg_integer(),
       Body :: iolist() | nobody | {Fun, FunArg},
-      Head :: [HeaderOption] | {Key, Value},
+      Head :: [HeaderOption],
       HeaderOption :: {Option, Value} | {code, StatusCode},
-      Option :: accept_ranges | allow,
-      Key :: atom() | string(),
+      Option :: accept_ranges | allow
+              | cache_control | content_MD5
+              | content_encoding | content_language
+              | content_length | content_location
+              | content_range | content_type | date
+              | etag | expires | last_modified
+              | location | pragma | retry_after
+              | server | trailer | transfer_encoding,
       Value :: string(),
       FunArg :: [term()],
       Fun :: fun((FunArg) -> sent | close | Body).
@@ -929,9 +599,8 @@ When `httpd` is shut down, it tries to execute [`remove/1`](`c:remove/1`) in
 each Erlang web server callback module. The programmer can use this function to
 clean up resources created in the store function.
 """.
--doc(#{group => <<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>}).
 -callback remove(ConfigDB) -> ok | {error, Reason} when
-      ConfigDB :: ets:tid(), Reason :: term().
+      ConfigDB :: config_db(), Reason :: term().
 
 -doc """
 Checks the validity of the configuration options before saving them in the
@@ -941,7 +610,6 @@ resolve possible dependencies among configuration options by changing the value
 of the option. This function only needs clauses for the options implemented by
 this particular callback module.
 """.
--doc(#{group => <<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>}).
 -callback store({Option, Value}, Config) ->
     {ok, {Option, NewValue}} | {error, Reason} when
       Option :: property(),
@@ -1003,42 +671,16 @@ reload_config(ConfigFile, Mode) ->
 -doc(#{equiv => info/2}).
 -spec info(Pid) -> HttpInformation when
       Pid :: pid(),
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer() | infinity}
-                   | {max_body_size, integer()}
-                   | {request_timeout, pos_integer() | infinity}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Pid) when is_pid(Pid) ->
     info(Pid, []).
 
@@ -1057,80 +699,29 @@ server.
 -spec info(Pid, Properties) -> HttpInformation  when
       Pid     :: pid(),
       Properties :: [atom()],
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
       ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer() | infinity}
-                   | {max_body_size, integer()}
-                   | {request_timeout, pos_integer() | infinity}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact};
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option();
           (Address, Port) -> HttpInformation when
       Address :: inet:ip_address(),
-      Port    :: integer(),
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      Port :: non_neg_integer(),
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer() | infinity}
-                   | {max_body_size, integer()}
-                   | {request_timeout, pos_integer() | infinity}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Pid, Properties) when is_pid(Pid) andalso is_list(Properties) ->
     {ok, ServiceInfo} = service_info(Pid), 
     Address = proplists:get_value(bind_address, ServiceInfo),
@@ -1151,82 +742,30 @@ info(Address, Port) when is_integer(Port) ->
       Address :: inet:ip_address() | any,
       Port    :: integer(),
       Profile :: atom(),
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer() | infinity}
-                   | {max_body_size, integer()}
-                   | {request_timeout, pos_integer() | infinity}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact};
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option();
           (Address, Port, Properties) -> HttpInformation when
       Address :: inet:ip_address() | any,
       Port    :: integer(),
       Properties :: [atom()],
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer() | infinity}
-                   | {max_body_size, integer()}
-                   | {request_timeout, pos_integer() | infinity}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Address, Port, Profile) when is_integer(Port), is_atom(Profile) ->
     httpd_conf:get_config(Address, Port, Profile);
 
@@ -1250,42 +789,16 @@ options of the server.
       Port    :: integer(),
       Profile :: atom(),
       Properties :: [atom()],
-      Path :: file:name_all(),
-      HttpInformation :: [CommonOption]
+      HttpInformation :: [MandatoryOption]
                        | [CommunicationOption]
                        | [ModOption]
                        | [LimitOption]
                        | [AdminOption],
-      CommonOption :: {port, non_neg_integer()}
-                | {server_name, string()}
-                | {server_root, Path}
-                | {document_root, Path},
-      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
-        | {profile, atom()}
-        | { socket_type,
-            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
-        | {ipfamily, inet | inet6}
-        | {minimum_bytes_per_second, integer()},
-      ModOption :: {modules, atom()},
-      LimitOption :: {customize, atom()}
-                   | {disable_chunked_transfer_encoding_send, boolean()}
-                   | {keep_alive, boolean()}
-                   | {keep_alive_timeout, integer() | infinity}
-                   | {max_body_size, integer()}
-                   | {request_timeout, pos_integer() | infinity}
-                   | {max_clients, integer()}
-                   | {max_header_size, integer()}
-                   | {max_content_length, integer()}
-                   | {max_uri_size, integer()}
-                   | {max_keep_alive_request, integer()}
-                   | {max_client_body_chunk, integer()},
-      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
-                   | {mime_type, string()}
-                   | {server_admin, string()}
-                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
-                   | {logger, Options::list()}
-                   | {log_format, common | combined}
-                   | {error_log_format, pretty | compact}.
+      MandatoryOption :: mandatory_option(),
+      CommunicationOption :: communication_option(),
+      ModOption :: mod_option(),
+      LimitOption :: limit_option(),
+      AdminOption :: admin_option().
 info(Address, Port, Profile, Properties) when is_integer(Port) andalso
 					      is_atom(Profile) andalso is_list(Properties) ->    
     httpd_conf:get_config(Address, Port, Profile, Properties).

--- a/lib/inets/src/http_server/mod_alias.erl
+++ b/lib/inets/src/http_server/mod_alias.erl
@@ -26,6 +26,8 @@ URL aliasing.
 
 Erlang web server internal API for handling of, for example, interaction data
 exported by module `mod_alias`.
+
+See [mod_alias - URL Aliasing](http_server.md#mod_alias) for more information about URL aliasing and the configuration file directives that can be used to configure URL aliasing.
 """.
 
 -export([do/1, 
@@ -40,6 +42,53 @@ exported by module `mod_alias`.
 -include("inets_internal.hrl").
 
 -define(VMODULE,"ALIAS").
+
+-export_type([url_alias_option/0]).
+
+-doc """
+- [](){: #prop_alias } **`{alias, {Alias, RealName}}`**  
+  `Alias = string()` and `RealName = string()`. `alias` allows documents to be
+  stored in the local file system instead of the `document_root` location. URLs
+  with a path beginning with url-path is mapped to local files beginning with
+  directory-filename, for example:
+
+  ```erlang
+  {alias, {"/image", "/ftp/pub/image"}}
+  ```
+
+  Access to http://your.server.org/image/foo.gif would refer to the file
+  /ftp/pub/image/foo.gif.
+
+- [](){: #prop_re_write } **`{re_write, {Re, Replacement}}`**  
+  `Re = string()` and `Replacement = string()`. `re_write` allows documents to
+  be stored in the local file system instead of the `document_root` location.
+  URLs are rewritten by `re:replace/3` to produce a path in the local
+  file-system, for example:
+
+  ```erlang
+  {re_write, {"^/[~]([^/]+)(.*)$", "/home/\\1/public\\2"}}
+  ```
+
+  Access to http://your.server.org/~bob/foo.gif would refer to the file
+  /home/bob/public/foo.gif.
+
+- [](){: #prop_dir_idx } **`{directory_index, [string()]}`**  
+  `directory_index` specifies a list of resources to look for if a client
+  requests a directory using a `/` at the end of the directory name. `file`
+  depicts the name of a file in the directory. Several files can be given, in
+  which case the server returns the first it finds, for example:
+
+  ```erlang
+  {directory_index, ["index.html", "welcome.html"]}
+  ```
+
+  Access to http://your.server.org/docs/ would return
+  http://your.server.org/docs/index.html or
+  http://your.server.org/docs/welcome.html if index.html does not exist.
+""".
+-type url_alias_option() :: {alias, {Alias :: string(), RealName :: string()}} |
+      {re_write, {Re :: string(), Replacement :: string()}} |
+      {directory_index, [string()]}.
 
 %% do
 
@@ -103,7 +152,7 @@ an argument. `config_db()` is the server config file in ETS table format as
 described in [Inets User's Guide](http_server.md).
 """.
 -spec real_name(ConfigDB, RequestURI, Aliases) -> ReturnPath when
-      ConfigDB :: ets:tid(),
+      ConfigDB :: httpd:config_db(),
       RequestURI :: string(),
       Aliases :: [{FakeName, RealName}],
       ReturnPath :: {ShortPath, Path, AfterPath},
@@ -177,7 +226,7 @@ returned. If it is a script, the resulting script path is in two parts,
 [Inets User's Guide](http_server.md).
 """.
 -spec real_script_name(ConfigDB, RequestURI, ScriptAliases) -> ReturnPath | not_a_script when
-      ConfigDB :: ets:tid(),
+      ConfigDB :: httpd:config_db(),
       RequestURI :: string(),
       ScriptAliases :: list() | [{FakeName, RealName}],
       ReturnPath :: {ShortPath, AfterPath},
@@ -218,7 +267,7 @@ server config file in ETS table format as described in
 
 """.
 -spec default_index(ConfigDB, Path) -> NewPath when
-      ConfigDB :: ets:tid(),
+      ConfigDB :: httpd:config_db(),
       Path :: string(),
       NewPath :: string().
 default_index(ConfigDB, Path) ->
@@ -252,7 +301,7 @@ generate a file `Path`. `config_db()` and `interaction_data()` are as defined in
 """.
 -spec path(Data, ConfigDB, RequestURI) -> Path when
       Data :: [{real_name, {Path, AfterPath}}],
-      ConfigDB :: ets:tid(),
+      ConfigDB :: httpd:config_db(),
       RequestURI :: string(),
       AfterPath :: string(),
       Path :: string().

--- a/lib/inets/src/http_server/mod_auth.erl
+++ b/lib/inets/src/http_server/mod_auth.erl
@@ -29,7 +29,7 @@ databases, or Mnesia databases.
 
 ### See also
 
-`m:httpd`, `m:mod_alias`
+`m:httpd`, `m:mod_alias`, [mod_auth - User Authentication](http_server.md#mod_auth).
 """.
 
 %% The functions that the webbserver call on startup stop
@@ -58,6 +58,114 @@ databases, or Mnesia databases.
 
 -type httpd_user() :: #httpd_user{}.
 -type httpd_group() :: #httpd_group{}.
+
+%%====================================================================
+%% TYPES
+%%====================================================================
+-export_type([auth_option/0]).
+
+-doc """
+`m:mod_auth` is configured by having a list of `{directory, {Path, DirProps}}` tuples in the configuration database.
+
+The properties for directories are as follows:
+
+- [](){: #prop_allow_from } **`{allow_from, all | [RegxpHostString]}`**  
+  Defines a set of hosts to be granted access to a given directory, for example:
+
+  ```erlang
+  {allow_from, ["123.34.56.11", "150.100.23"]}
+  ```
+
+  The host `123.34.56.11` and all machines on the `150.100.23` subnet are
+  allowed access.
+
+- [](){: #prop_deny_from } **`{deny_from, all | [RegxpHostString]}`**  
+  Defines a set of hosts to be denied access to a given directory, for example:
+
+  ```text
+  {deny_from, ["123.34.56.11", "150.100.23"]}
+  ```
+
+  The host `123.34.56.11` and all machines on the `150.100.23` subnet are not
+  allowed access.
+
+- [](){: #prop_auth_type } **`{auth_type, plain | dets | mnesia}`**  
+  Sets the type of authentication database that is used for the directory. The
+  key difference between the different methods is that dynamic data can be saved
+  when Mnesia and Dets are used.
+
+- [](){: #prop_auth_user_file } **`{auth_user_file, path()}`**  
+  Sets the name of a file containing the list of users and passwords for user
+  authentication. The filename can be either absolute or relative to the
+  `server_root`. If using the plain storage method, this file is a plain text
+  file where each line contains a username followed by a colon, followed by the
+  non-encrypted password. If usernames are duplicated, the behavior is
+  undefined.
+
+  Example:
+
+  ```text
+  ragnar:s7Xxv7
+  edward:wwjau8
+  ```
+
+  If the Dets storage method is used, the user database is maintained by Dets
+  and must not be edited by hand. Use the API functions in module `mod_auth` to
+  create/edit the user database. This directive is ignored if the Mnesia storage
+  method is used. For security reasons, ensure that `auth_user_file` is stored
+  outside the document tree of the web server. If it is placed in the directory
+  that it protects, clients can download it.
+
+- [](){: #prop_auth_group_file } **`{auth_group_file, path()}`**  
+  Sets the name of a file containing the list of user groups for user
+  authentication. The filename can be either absolute or relative to the
+  `server_root`. If the plain storage method is used, the group file is a plain
+  text file, where each line contains a group name followed by a colon, followed
+  by the members usernames separated by spaces.
+
+  Example:
+
+  ```text
+  group1: bob joe ante
+  ```
+
+  If the Dets storage method is used, the group database is maintained by Dets
+  and must not be edited by hand. Use the API for module `mod_auth` to
+  create/edit the group database. This directive is ignored if the Mnesia
+  storage method is used. For security reasons, ensure that the
+  `auth_group_file` is stored outside the document tree of the web server. If it
+  is placed in the directory that it protects, clients can download it.
+
+- [](){: #prop_auth_name } **`{auth_name, string()}`**  
+  Sets the name of the authorization realm (auth-domain) for a directory. This
+  string informs the client about which username and password to use.
+
+- [](){: #prop_auth_access_passwd } **`{auth_access_password, string()}`**  
+  If set to other than `"NoPassword"`, the password is required for all API calls.
+  If the password is set to `"DummyPassword"`, the password must be changed before
+  any other API calls. To secure the authenticating data, the password must be
+  changed after the web server is started. Otherwise it is written in clear text
+  in the configuration file.
+
+- [](){: #prop_req_user } **`{require_user, [string()]}`**  
+  Defines users to grant access to a given directory using a secret password.
+
+- [](){: #prop_req_grp } **`{require_group, [string()]}`**  
+  Defines users to grant access to a given directory using a secret password.
+""".
+-type auth_option() ::
+    {directory, {Path :: file:name_all(),
+        [DirProps ::
+              {allow_from, all | [RexExp :: string()]} |
+              {deny_from, all | [RexExp :: string()]} |
+              {auth_type, plain | dets | mnesia} |
+              {auth_user_file, file:name_all()} |
+              {auth_group_file, file:name_all()} |
+              {auth_name, string()} |
+              {auth_access_password, string()} |
+              {require_user, [string()]} |
+              {require_group, [string()]}]}}.
+
 
 %%====================================================================
 %% Internal application API

--- a/lib/inets/src/http_server/mod_disk_log.erl
+++ b/lib/inets/src/http_server/mod_disk_log.erl
@@ -21,7 +21,11 @@
 %%
 %%
 -module(mod_disk_log).
--moduledoc false.
+-moduledoc """
+Inets httpd disk logging module.
+
+See [mod_disk_log - Disk Logging](http_server.md#mod_disk_log) for more information about disk logging and the configuration file directives that can be used to configure disk logging.
+""".
 
 %% Application internal API
 -export([error_log/2, report_error/2, security_log/2]).
@@ -35,10 +39,64 @@
 -include("httpd_internal.hrl").
 
 %%%=========================================================================
+%%%  TYPES
+%%%=========================================================================
+-export_type([disk_log_option/0]).
+
+-doc """
+- [](){: #prop_dlog_format } **`{disk_log_format, internal | external}`**  
+  Defines the file format of the log files. See `disk_log` for details. If the
+  internal file format is used, the log file is repaired after a crash. When a
+  log file is repaired, data can disappear. When the external file format is
+  used, `httpd` does not start if the log file is broken. Default is `external`.
+
+- [](){: #prop_edlog } **`{error_disk_log, path()}`**  
+  Defines the filename of the (`m:disk_log`) error log file to be used to log
+  server errors. If the filename does not begin with a slash (/), it is assumed
+  to be relative to the `server_root`.
+
+- [](){: #prop_edlog_size } **`{error_disk_log_size, {MaxBytes, MaxFiles}}`**  
+  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
+  the (`m:disk_log`) error log file. This file is of type wrap log and max bytes
+  is written to each file and max files is used before the first file is
+  truncated and reused.
+
+- [](){: #prop_sdlog } **`{security_disk_log, path()}`**  
+  Defines the filename of the (`m:disk_log`) access log file logging incoming
+  security events, that is, authenticated requests. If the filename does not
+  begin with a slash (/), it is assumed to be relative to the `server_root`.
+
+- [](){: #prop_sdlog_size } **`{security_disk_log_size, {MaxBytes, MaxFiles}}`**  
+  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
+  the `m:disk_log` access log file. This file is of type wrap log and max bytes
+  is written to each file and max files is used before the first file is
+  truncated and reused.
+
+- [](){: #prop_tdlog } **`{transfer_disk_log, path()}`**  
+  Defines the filename of the (`m:disk_log`) access log file logging incoming
+  requests. If the filename does not begin with a slash (/), it is assumed to be
+  relative to the `server_root`.
+
+- [](){: #prop_tdlog_size } **`{transfer_disk_log_size, {MaxBytes, MaxFiles}}`**  
+  `MaxBytes = integer()` and `MaxFiles = integer()`. Defines the properties of
+  the `m:disk_log` access log file. This file is of type wrap log and max bytes
+  is written to each file and max files is used before the first file is
+  truncated and reused.
+""".
+-type disk_log_option() :: {transfer_disk_log, string()}
+    | {error_disk_log, string()}
+    | {security_disk_log, string()}
+    | {transfer_disk_log_size, {non_neg_integer(), non_neg_integer()}}
+    | {error_disk_log_size, {non_neg_integer(), non_neg_integer()}}
+    | {security_disk_log_size, {non_neg_integer(), non_neg_integer()}}
+    | {disk_log_format, internal | external}.
+
+%%%=========================================================================
 %%%  API 
 %%%=========================================================================
 
 %% security_log
+-doc false.
 security_log(#mod{config_db = ConfigDb} = Info, Event) ->
     Format = get_log_format(ConfigDb),
     Date = httpd_util:custom_date(),
@@ -50,6 +108,7 @@ security_log(#mod{config_db = ConfigDb} = Info, Event) ->
 	    write(Log, Entry, Format)
     end.
 
+-doc false.
 report_error(ConfigDB, Error) ->
     Format = get_log_format(ConfigDB),
     Date = httpd_util:custom_date(),
@@ -61,10 +120,12 @@ report_error(ConfigDB, Error) ->
 	    write(Log, Entry, Format)
     end.
 
+-doc false.
 error_log(Info, Reason) ->
     Date = httpd_util:custom_date(),
     error_log(Info, Date, Reason).
 
+-doc false.
 error_log(#mod{config_db = ConfigDB} = Info, Date, Reason) ->
     Format = get_log_format(ConfigDB),
      case httpd_log:error_entry(error_disk_log, no_error_log, 
@@ -85,6 +146,7 @@ error_log(#mod{config_db = ConfigDB} = Info, Date, Reason) ->
 %%
 %% Description:  See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 do(Info) ->
     AuthUser  = auth_user(Info#mod.data),
     Date      = httpd_util:custom_date(),
@@ -138,6 +200,7 @@ do(Info) ->
 %%
 %% Description: See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 store({transfer_disk_log,TransferDiskLog}, ConfigList) 
   when is_list(TransferDiskLog) ->
     case create_disk_log(TransferDiskLog, 
@@ -196,6 +259,7 @@ store({disk_log_format, Value}, _) ->
 %%
 %% Description: See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 remove(ConfigDB) ->
     lists:foreach(fun([DiskLog]) -> close(DiskLog) end,
 		  ets:match(ConfigDB,{transfer_disk_log,'$1'})),

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -53,6 +53,38 @@ them as common CGI scripts.
 %%%=========================================================================
 %%%  Types
 %%%=========================================================================
+-export_type([esi_option/0]).
+
+-doc """
+- [](){: #prop_esi_alias } **`{erl_script_alias, {URLPath, [AllowedModule]}}`**  
+  `URLPath = string()` and `AllowedModule = atom()`. `erl_script_alias` marks
+  all URLs matching url-path as erl scheme scripts. A matching URL is mapped
+  into a specific module and function, for example:
+
+  ```erlang
+  {erl_script_alias, {"/cgi-bin/example", [httpd_example]}}
+  ```
+
+  A request to http://your.server.org/cgi-bin/example/httpd_example:yahoo would
+  refer to httpd_example:yahoo/3 or, if that does not exist,
+  httpd_example:yahoo/2 and http://your.server.org/cgi-bin/example/other:yahoo
+  would not be allowed to execute.
+
+- [](){: #prop_esi_nocache } **`{erl_script_nocache, boolean()}`**  
+  If `erl_script_nocache` is set to `true`, the server adds HTTP header fields
+  preventing proxies from caching the page. This is generally a good idea for
+  dynamic content, as the content often varies between each request. Default is
+  `false`.
+
+- [](){: #prop_esi_timeout } **`{erl_script_timeout, integer()}`**  
+  If `erl_script_timeout` sets the time in seconds the server waits between each
+  chunk of data to be delivered through `mod_esi:deliver/2`. Default is `15`.
+  This is only relevant for scripts that use the erl scheme.
+""".
+-type esi_option() :: {erl_script_alias, {string(), [atom()]}} |
+                      {erl_script_nocache, boolean()} |
+                      {erl_script_timeout, non_neg_integer()}.
+
 -doc """
 Environment data associated with a request.
 
@@ -111,7 +143,7 @@ Called by `mod_esi` in response to requests.
 
 `Module` must be found in the code path and export `Function` with an arity of
 three. An `erl_script_alias` must also be set up in the configuration file for
-the web server, see [the ESI properties documentation](`m:httpd#prop_esi_alias`).
+the web server, see [the ESI properties documentation](`m:mod_esi#prop_esi_alias`).
 
 The `Module` and `Function` that are called depend on the URL. See [the ESI
 introductory documentation](http_server.md#esi) for more details.
@@ -169,7 +201,6 @@ JSON response body, one could pass the following:
 "status: 201 Created\r\ncontent-type: application/json\r\n\r\n{}"
 ```
 """.
--doc(#{group => <<"ESI Callback Functions">>}).
 -callback 'Function'(SessionID, Env, Input) -> {continue, State} | _
                         when
                             SessionID :: session_id(),

--- a/lib/inets/src/http_server/mod_log.erl
+++ b/lib/inets/src/http_server/mod_log.erl
@@ -21,7 +21,9 @@
 %%
 %%
 -module(mod_log).
--moduledoc false.
+-moduledoc """
+Inets httpd logging module.
+""".
 
 %% Application internal API
 -export([error_log/2, security_log/2, report_error/2]).
@@ -29,15 +31,42 @@
 %% Callback API
 -export([do/1, load/2, store/2, remove/1]).
 
+-behaviour(httpd).
+
 -include("httpd.hrl").
 -include("httpd_internal.hrl").
 -define(VMODULE,"LOG").
+
+%%%=========================================================================
+%%%  TYPES
+%%%=========================================================================
+
+-export_type([log_option/0]).
+
+-doc """
+- [](){: #prop_elog } **`{error_log, path()}`**  
+  Defines the filename of the error log file to be used to log server errors. If
+  the filename does not begin with a slash (/), it is assumed to be relative to
+  the `server_root`.
+
+- [](){: #prop_slog } **`{security_log, path()}`**  
+  Defines the filename of the access log file to be used to log security events.
+  If the filename does not begin with a slash (/), it is assumed to be relative
+  to the `server_root`.
+
+- [](){: #prop_tlog } **`{transfer_log, path()}`**  
+  Defines the filename of the access log file to be used to log incoming
+  requests. If the filename does not begin with a slash (/), it is assumed to be
+  relative to the `server_root`.
+""".
+-type log_option() :: {transfer_log, string()} | {error_log, string()} | {security_log, string()}.
 
 %%%=========================================================================
 %%%  API 
 %%%=========================================================================
 
 %% security log
+-doc false.
 security_log(Info, ReasonStr) ->
     Date = httpd_util:custom_date(),
     case httpd_log:security_entry(security_log, no_security_log, Info,
@@ -49,6 +78,7 @@ security_log(Info, ReasonStr) ->
     end.
 
 %% error_log
+-doc false.
 error_log(Info, Reason) ->
     Date = httpd_util:custom_date(),
     error_log(Info, Date, Reason).
@@ -62,6 +92,7 @@ error_log(Info, Date, Reason) ->
 	    io:format(Log, "~s", [Entry])
     end.
 
+-doc false.
 report_error(ConfigDB, Error) ->
     Date = httpd_util:custom_date(),
     case httpd_log:error_report_entry(error_log, no_error_log, ConfigDB,
@@ -82,6 +113,7 @@ report_error(ConfigDB, Error) ->
 %%
 %% Description:  See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 do(Info) ->
     AuthUser = auth_user(Info#mod.data),
     Date     = httpd_util:custom_date(),
@@ -130,6 +162,7 @@ do(Info) ->
 %%
 %% Description: See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 load("TransferLog " ++ TransferLog, []) ->
     {ok,[],{transfer_log,string:strip(TransferLog)}};
 load("ErrorLog " ++ ErrorLog, []) ->
@@ -147,6 +180,7 @@ load("SecurityLog " ++ SecurityLog, []) ->
 %%
 %% Description: See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 store({transfer_log,TransferLog}, ConfigList) when is_list(TransferLog)->
     case create_log(TransferLog,ConfigList) of
 	{ok,TransferLogStream} ->
@@ -180,6 +214,7 @@ store({security_log, SecurityLog}, _) ->
 %%
 %% Description: See httpd(3) ESWAPI CALLBACK FUNCTIONS
 %%-------------------------------------------------------------------------
+-doc false.
 remove(ConfigDB) ->
     lists:foreach(fun([Stream]) -> file:close(Stream) end,
 		  ets:match(ConfigDB,{transfer_log,'$1'})),

--- a/lib/inets/src/http_server/mod_security.erl
+++ b/lib/inets/src/http_server/mod_security.erl
@@ -41,6 +41,50 @@ Security Audit and Trailing Functionality
 
 -define(VMODULE,"SEC").
 
+%%====================================================================
+%% TYPES
+%%====================================================================
+-export_type([security_option/0]).
+
+-doc """
+`m:mod_auth` is configured by having a list of `{security_directory, {Path, DirProps}}` tuples in the configuration database.
+
+The properties for the security directories are as follows:
+
+- [](){: #prop_data_file } **`{data_file, path()}`**  
+  Name of the security data file. The filename can either be absolute or
+  relative to the `server_root`. This file is used to store persistent data for
+  module `mod_security`.
+
+- [](){: #prop_max_retries } **`{max_retries, integer()}`**  
+  Specifies the maximum number of attempts to authenticate a user before the
+  user is blocked out. If a user successfully authenticates while blocked, the
+  user receives a 403 (Forbidden) response from the server. If the user makes a
+  failed attempt while blocked, the server returns 401 (Unauthorized), for
+  security reasons. Default is `3`. Can be set to infinity.
+
+- [](){: #prop_block_time } **`{block_time, integer()}`**  
+  Specifies the number of minutes a user is blocked. After this time has passed,
+  the user automatically regains access. Default is `60`.
+
+- [](){: #prop_fail_exp_time } **`{fail_expire_time, integer()}`**  
+  Specifies the number of minutes a failed user authentication is remembered. If
+  a user authenticates after this time has passed, the previous failed
+  authentications are forgotten. Default is `30`.
+
+- [](){: #prop_auth_timeout } **`{auth_timeout, integer()}`**  
+  Specifies the number of seconds a successful user authentication is
+  remembered. After this time has passed, the authentication is no longer
+  reported. Default is `30`.
+""".
+-type security_option() ::
+        {security_directory, {Path :: file:name_all(),
+        [DirProps ::
+            {data_file, file:name_all()} |
+            {max_retries, integer()} |
+            {block_time, integer()} |
+            {fail_expire_time, integer()} |
+            {auth_timeout, integer()}]}}.
 
 %%====================================================================
 %% Internal application API

--- a/lib/inets/src/inets_app/inets.erl
+++ b/lib/inets/src/inets_app/inets.erl
@@ -31,19 +31,6 @@ The Inets services API.
 This module provides the most basic API to the clients and servers that are part
 of the `Inets` application, such as start and stop.
 
-[](){: #common_data_types }
-
-### Data types
-
-Type definitions that are used more than once in this module:
-
-`service() = httpc | httpd`
-
-`property() = atom()`
-
-### See also
-
-`m:httpc`, `m:httpd`
 """.
 
 -compile([{nowarn_possibly_unsafe_function, {file, consult, 1}}]).
@@ -73,7 +60,7 @@ Type definitions that are used more than once in this module:
 %% Description: Starts the inets application. Default type
 %% is temporary. see application(3)
 %%--------------------------------------------------------------------
--doc(#{equiv => start/1}).
+-doc(#{equiv => start(temporary)}).
 -spec start() -> ok | {error, Reason} when Reason :: term().
 start() ->
     application:start(inets, temporary).
@@ -115,14 +102,10 @@ start(Type) ->
 %% in place and in some sense the calling process has now become the
 %% top supervisor.
 %% --------------------------------------------------------------------
--doc(#{equiv => start/3}).
+-doc(#{equiv => start(Service, ServiceConfig, inets)}).
 -spec start(Service, ServiceConfig) -> Result when
       Service :: inets_service(),
-      ServiceConfig :: ConfPropList | ConfFile,
-      ConfPropList :: [{Property, Value}],
-      ConfFile :: string(),
-      Property :: term(),
-      Value :: term(),
+      ServiceConfig :: proplists:proplist(),
       Result :: {ok, pid()} | {error, term()}.
 start(Service, ServiceConfig) ->
     start_service(Service, ServiceConfig, inets).
@@ -130,6 +113,8 @@ start(Service, ServiceConfig) ->
 -doc """
 Dynamically starts an `Inets` service after the `Inets` application has been
 started.
+
+See `m:httpd` and `m:httpc` for details on the service configuration.
 
 > #### Note {: .info }
 >
@@ -149,15 +134,7 @@ started.
 > The stand_alone option is considered deprecated.
 >
 """.
--spec start(Service, ServiceConfig, How) -> Result when
-      Service :: inets_service(),
-      ServiceConfig :: ConfPropList | ConfFile,
-      How :: inets | stand_alone,
-      ConfPropList :: [{Property, Value}],
-      ConfFile :: string(),
-      Property :: term(),
-      Value :: term(),
-      Result :: {ok, pid()} | {error, term()}.
+-spec start(Service :: inets_service(), ServiceConfig :: proplists:proplist(), How :: inets | stand_alone) -> {ok, pid()} | {error, term()}.
 start(Service, ServiceConfig, How) ->
     start_service(Service, ServiceConfig, How).
 


### PR DESCRIPTION
In the translation from xml to markdown the properties documentation for httpd was left as is, which does not look great in ex_doc. This commit moves type documentation from the moduledoc to specific types and extracts the mod_* docs into their respective module.

As I did not want to migrate the mod_cgi and mod_action docs just for them to be removed later, they have been removed already in this doc refactor.