### PR TITLE
Cleanup documentation for coding agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ TAGS
 # IntelliJ IDEA
 .idea
 
+# Crash dumps, written to whatever directory the emulator was started in.
+erl_crash.dump
+
 autom4te.cache
 configure.result.*
 *.beam

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,9 @@ make
 * When something stops making sense after switching branches, `git clean -Xfdq`
   and build again.
 * For debug, asan, lcnt and valgrind emulators see
-  [Types and Flavors](HOWTO/DEVELOPMENT.md#types-and-flavors). Note that an
-  unrecognized `TYPE` is silently treated as `opt`, and that a plain `make` only
-  rebuilds the default type.
+  [Types and Flavors](HOWTO/DEVELOPMENT.md#types-and-flavors). Note that a plain
+  `make` only rebuilds the default type, so a debug or asan emulator you built
+  earlier can be older than your source tree.
 
 **Before you debug a failure that makes no sense against the source, read
 [When the build lies to you](HOWTO/DEVELOPMENT.md#when-the-build-lies-to-you).**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,9 @@ git diff --check
 
 `./otp_build check --help` lists the individual checks. See
 [Static analysis](HOWTO/DEVELOPMENT.md#static-analysis) for what each one
-corresponds to in CI, and for the `clang-format` version trap.
+corresponds to in CI. `format-check` requires the `clang-format` major version
+in `make/clang_format_vsn`; if it is not first in your path, pass
+`CLANG_FORMAT=clang-format-<vsn>`.
 
 If you added something else that CI checks, such as a shell script or a
 workflow file, run that checker locally too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,196 @@
+<!--
+%CopyrightBegin%
+
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Ericsson AB 2026. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+%CopyrightEnd%
+-->
+
+# AGENTS.md
+
+Orientation for coding agents, and for anyone who wants the short form. This
+file is a map and a checklist. The long form lives in [HOWTO/](HOWTO/) and
+[CONTRIBUTING.md](CONTRIBUTING.md), and this file links there rather than
+repeating them.
+
+## Ground rules
+
+1. **`export ERL_TOP=$(pwd)` in every shell.** Most of the make system needs it.
+   If you are an agent whose environment does not survive from one command to
+   the next, set it in the same command. A missing `ERL_TOP` usually surfaces as
+   a confusing "No rule to make target".
+2. **Push to your own fork, never to `erlang/otp`.** Name the remote explicitly;
+   do not rely on what a bare `git push` will do.
+3. **Never work directly on `maint` or `master`.** Bug fixes are based on
+   `maint`, new features on `master`. See [CONTRIBUTING.md](CONTRIBUTING.md).
+4. **Do not include updates to `bootstrap/` or `erts/preloaded/ebin/` in a pull
+   request.** They are committed binaries and cannot be reviewed. You may have
+   to regenerate them while developing; drop the commit before submitting.
+5. **Do not merge `maint` or `master` into your branch.** Rebase.
+6. **Run the checks locally before pushing.** A Github Actions round trip is
+   roughly half an hour; the same checks take minutes locally.
+7. **Report what you actually ran.** A build that used a stale bootstrap, a
+   stale PLT or an emulator of the wrong type has not validated anything. Say so
+   rather than reporting a pass.
+
+## Where things are
+
+| Path | What it is |
+| --- | --- |
+| `erts/emulator/` | The virtual machine. `beam/` interpreter and BIFs, `beam/jit/` BeamAsm |
+| `erts/preloaded/src/` | Erlang code compiled into the VM |
+| `lib/$APP/{src,test,doc}` | The applications |
+| `erts/emulator/test/`, `erts/test/` | Emulator and system test suites |
+| `bootstrap/` | Committed BEAM files used to compile Erlang/OTP |
+| `make/` | Shared make rules. `make/test_target_script.sh` implements `make test` |
+| `scripts/` | `otp_build_check`, `license-header.es`, `run-dialyzer`, `pre-push` |
+| `.github/workflows/` | CI. `main.yaml` is the entry point, `reusable-*.yaml` the jobs |
+| `HOWTO/` | The documentation. Start with [DEVELOPMENT.md](HOWTO/DEVELOPMENT.md) |
+
+## Build
+
+```bash
+export ERL_TOP=$(pwd)
+./configure          # ./otp_build configure on Windows
+make
+```
+
+* `make emulator` builds erts and its tools only, which is the usual inner loop
+  for VM work. `make $APP` builds one application but not its dependencies, so
+  build everything once first.
+* Re-run `./configure` after changing a `Makefile`, and `./otp_build
+  update_configure` after changing a `configure.ac` or an `.m4` file.
+* `export ERLC_USE_SERVER=true` and `./otp_build boot -t` make development
+  builds considerably faster. See
+  [Faster builds](HOWTO/DEVELOPMENT.md#faster-builds).
+* When something stops making sense after switching branches, `git clean -Xfdq`
+  and build again.
+* For debug, asan, lcnt and valgrind emulators see
+  [Types and Flavors](HOWTO/DEVELOPMENT.md#types-and-flavors). Note that an
+  unrecognized `TYPE` is silently treated as `opt`, and that a plain `make` only
+  rebuilds the default type.
+
+**Before you debug a failure that makes no sense against the source, read
+[When the build lies to you](HOWTO/DEVELOPMENT.md#when-the-build-lies-to-you).**
+Stale objects after a header change, a stale primary bootstrap and stale
+non-default emulators all produce builds that pass without testing what you
+think they test.
+
+## Test
+
+```bash
+make stdlib_test                                            # one application
+make stdlib_test ARGS="-suite lists_SUITE"                  # one suite
+make emulator_test ARGS="-suite binary_SUITE -case deep_bitstr_lists"
+make stdlib_test ARGS="-suite lists_SUITE -repeat 25"       # soak a flaky case
+ERL_ARGS="+hmqd off_heap" make emulator_test                # extra emulator flags
+```
+
+Do not call `ct_run` directly; `make test` sets up the test environment first.
+Everything in `ARGS` is passed to `ct_run` verbatim. This is the supported way
+to run the tests and is documented in [TESTING.md](HOWTO/TESTING.md).
+
+Read the results in `lib/$APP/make_test_dir/ct_logs/index.html`, or
+`erts/emulator/make_test_dir/ct_logs/index.html` for `make emulator_test`.
+`make test` prints the link when it finishes.
+
+Some applications release the whole system before testing, which is slow to
+iterate against, and `TEST_NEEDS_RELEASE=false` skips that while you work on a
+single case. See
+[Running test cases](HOWTO/DEVELOPMENT.md#running-test-cases) for that, for the
+`ARGS` environment variable and for how `ERL_AFLAGS` reaches peer nodes. Those
+are details of the make system rather than supported interfaces, so check them
+against the guide rather than assuming they still work as described.
+
+## Before you push
+
+```bash
+./otp_build check                   # docs, links, dialyzer, format, license
+./otp_build check --tests $APP      # narrow it while iterating
+scripts/license-header.es ci        # not "reuse lint"
+make -C erts/emulator format-check  # clang-format, JIT sources only
+git diff --check
+```
+
+`./otp_build check --help` lists the individual checks. See
+[Static analysis](HOWTO/DEVELOPMENT.md#static-analysis) for what each one
+corresponds to in CI, and for the `clang-format` version trap.
+
+If you added something else that CI checks, such as a shell script or a
+workflow file, run that checker locally too.
+
+## Continuous integration
+
+```bash
+gh run list --branch $BRANCH -R $YOUR_GITHUB_USER/otp
+gh run view $RUN_ID -R $YOUR_GITHUB_USER/otp --log-failed
+gh run download $RUN_ID -R $YOUR_GITHUB_USER/otp -n test_results
+gh run rerun $RUN_ID -R $YOUR_GITHUB_USER/otp --failed
+```
+
+`gh` defaults to the repository `origin` points at, so pass `-R` when working on
+a fork. Compare a failing job against the same job on the parent commit before
+concluding that your change caused it. See
+[Debugging Github Actions failures](HOWTO/DEVELOPMENT.md#debugging-github-actions-failures).
+
+## Documentation
+
+`make docs`, or `cd lib/$APP && make docs`, and open
+`lib/$APP/doc/html/index.html`. Requires a built tree and `ex_doc`
+(`./otp_build download_ex_doc`).
+
+Warnings are errors when the repository is fully built, which is why a
+documentation change can pass locally and fail in CI. See
+[Common documentation build failures](HOWTO/DOCUMENTATION.md#common-documentation-build-failures).
+
+## Commits and pull requests
+
+[CONTRIBUTING.md](CONTRIBUTING.md) is the authority. The points most often
+missed:
+
+* Small, self-contained commits that each compile and pass the relevant tests,
+  so that `git bisect` works. Changes to different applications go in different
+  commits.
+* First line at most 72 characters, no trailing period. Explain **why** in the
+  body.
+* Correct a commit that is under review with `git commit --fixup=<commit>`
+  rather than by rewriting history.
+* Check `git status` and `git diff --cached` before every commit. Note that
+  `git checkout <commit> -- <path>` stages what it restores.
+* Write a test case that fails before the fix and passes after it.
+
+### Disclosing AI assistance
+
+*This is a proposal and not yet project policy.* Following the convention used
+by the Linux kernel, a commit or pull request description written with the help
+of an AI assistant carries a single trailer naming the model:
+
+```text
+Assisted-by: <Assistant>:<model-id>
+```
+
+`Signed-off-by` certifies the Developer Certificate of Origin and belongs to the
+human submitter; it must not be added on an assistant's behalf, and neither must
+`Co-authored-by` or `Co-developed-by`. The human submitter remains responsible
+for reviewing the code and owning the contribution.
+
+## Measuring performance
+
+Benchmark and profile an optimized build, not a debug one, and confirm which
+emulator you are running before trusting a number. Measure the unchanged tree
+twice before attributing a difference to a change; allocator and garbage
+collection timing is noisy. When reporting a result, say what it does not cover.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,9 @@ See the [Testing](https://github.com/erlang/otp/blob/master/HOWTO/TESTING.md) an
 [Development](https://github.com/erlang/otp/blob/master/HOWTO/DEVELOPMENT.md) howtos
 for details on how to use run tests and use the Erlang/OTP make system.
 
+[AGENTS.md](AGENTS.md) is a condensed version of the same material, written for
+coding agents but useful to anyone who wants the short form.
+
 Make sure that your branch contains clean commits:
 
 * Don't make the first line in the commit message longer than 72 characters.
@@ -164,6 +167,14 @@ conflicts or include the latest changes.
 
 * Check for unnecessary whitespace before committing with `git diff --check`.
 However, do not fix preexisting whitespace errors in otherwise untouched source lines.
+
+* Check what you are about to commit with `git status` and `git diff --cached`.
+Note in particular that `git checkout <commit> -- <path>` stages what it restores,
+so it is easy to sweep unrelated files into an otherwise small commit.
+
+* When correcting a commit that is already being reviewed, add a fixup commit with
+`git commit --fixup=<commit>` and squash it with `git rebase --autosquash` before the
+final push, rather than rewriting the history that the reviewer is reading.
 
 Check your coding style:
 

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -445,6 +445,10 @@ make -C erts/emulator format-check  # clang-format, JIT sources only
 git diff --check                    # whitespace errors
 ```
 
+`make dialyzer` builds a plt in `lib/$APPLICATION_NAME/priv/plt` from the
+applications it depends on, and rebuilds it whenever any of those have been
+rebuilt. The first run after a full build therefore takes a while.
+
 *NOTE*: The license header check is `scripts/license-header.es ci`, which is
 what Github Actions runs. `reuse lint` is a different tool with a different
 scope and will report the whole repository as non-compliant. See
@@ -492,9 +496,6 @@ is a separate binary. A plain `make` only rebuilds the default one, so your
 debug or asan emulator can be days older than your source tree while `make`
 reports success. See [Types and Flavors](#types-and-flavors) for how to check
 what you are actually running.
-
-**A stale dialyzer PLT.** The PLT is not invalidated when the application beam
-files are rebuilt. If the warnings do not match the code, rebuild the PLT.
 
 **Shadowed executables.** Erlang version managers put their own `erl`, `erlc`
 and `ex_doc` ahead of the ones in the source tree. When you mean to use the tree

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -61,6 +61,9 @@ with.
     5. [Static analysis](#static-analysis)
 5. [When the build lies to you](#when-the-build-lies-to-you)
 6. [Running test cases](#running-test-cases)
+    1. [Where the test logs end up](#where-the-test-logs-end-up)
+    2. [Repeating and targeting test cases](#repeating-and-targeting-test-cases)
+    3. [Testing without releasing](#testing-without-releasing)
 7. [Writing and building documentation](#writing-and-building-documentation)
     1. [Validating documentation](#validating-documentation)
 8. [Github Actions](#github-actions)
@@ -506,7 +509,84 @@ full rebuild is usually faster than working out which one you hit.
 
 ## Running test cases
 
-There is a detailed description about how to run tests in [TESTING.md](TESTING.md).
+There is a detailed description about how to run tests in [TESTING.md](TESTING.md),
+which is also where the supported way of running them is described. The rest of
+this section covers details of how the make system runs the tests. As with
+everything else in this guide, they may change without notice.
+
+### Where the test logs end up
+
+When you run `make test` in the source tree the results are written to a
+`make_test_dir` next to the application being tested:
+
+```text
+lib/$APPLICATION_NAME/make_test_dir/ct_logs/index.html
+erts/emulator/make_test_dir/ct_logs/index.html          # make emulator_test
+```
+
+`make test` prints a link to this index when it finishes, both when the tests
+pass and when they fail. The logs for an individual suite are one level further
+down, in `ct_logs/ct_run.$NODE.$TIMESTAMP/`.
+
+`make_test_dir` is generated and is ignored by git, so nothing in it should be
+edited. In particular the test specification found there is a copy; the one to
+change is in `lib/$APPLICATION_NAME/test/`.
+
+### Repeating and targeting test cases
+
+`ARGS` is read from the environment as well as from the make command line, so
+these are equivalent:
+
+```bash
+make stdlib_test ARGS="-suite lists_SUITE"
+ARGS="-suite lists_SUITE" make stdlib_test
+```
+
+The environment form is useful for targeting a single test case in an
+environment where you cannot easily change the command that is run, such as
+inside an already built container.
+
+To chase a race you can repeat the whole selection with `ct_run`'s `-repeat`
+flag. `ct_run` exits with a non-zero status if any iteration failed, so a
+successful `make` means every iteration passed:
+
+```bash
+make emulator_test ARGS="-suite signal_SUITE -case dirty_signal_handling -repeat 25"
+```
+
+Note the difference between `ERL_ARGS` and `ERL_AFLAGS` here. `ERL_ARGS` is
+passed to `ct_run` after `-erl_args` and so only reaches the node running the
+tests, whereas `ERL_FLAGS` and `ERL_AFLAGS` are picked up from the environment
+by every emulator started, including the peer nodes that the suites start
+themselves. That is how `TYPE` and `FLAVOR` reach the peers; the make system
+appends `-emu_type` and `-emu_flavor` to `ERL_AFLAGS`. It also means that a
+suite which needs to control its peers has to pass the flag on the peer's own
+command line, which takes precedence.
+
+### Testing without releasing
+
+Some applications have to be tested against a released Erlang/OTP rather than
+the source tree, because they test release handling, installation paths or code
+upgrade. Those applications set `TEST_NEEDS_RELEASE=true` in their `Makefile`:
+
+```bash
+grep -l TEST_NEEDS_RELEASE=true lib/*/Makefile
+```
+
+For them `make $APPLICATION_NAME_test` does a full release into `make_test_dir`
+first and runs the tests against that, which adds several minutes to every
+iteration.
+
+While working on a single test case you can skip that step:
+
+```bash
+make stdlib_test TEST_NEEDS_RELEASE=false ARGS="-suite lists_SUITE -case member"
+```
+
+The tests then run against the source tree instead, which is a great deal
+faster. Test cases that genuinely need a released system will fail or be skipped
+when you do this, so run them again without the override before concluding that
+a change works.
 
 ## Writing and building documentation
 

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -475,10 +475,14 @@ is a class of problem where the build succeeds but does not build, or does not
 test, what you think it does. They are all easier to recognise than to debug, so
 they are collected here.
 
-**Stale object files after a header change.** Changing an `enum` member or a
-struct layout in a widely included header does not reliably rebuild every object
-file that depends on it. Freshly built objects then disagree with stale ones
-about numeric values or offsets, which shows up as assertion or crash failures
+**Stale object files after a header change.** The header dependencies of the
+emulator are generated in one pass rather than as a side effect of each
+compilation. That pass runs when a source file is added or removed, when
+`configure` has rewritten the `Makefile`, and when the generated sources change,
+but *not* when you add an `#include` to a file that already existed. Until the
+dependencies are generated again, changes to that header do not rebuild that
+object file, and a freshly built object can disagree with a stale one about a
+struct layout or an enum value. That shows up as assertion or crash failures
 that are impossible given the source code. If a failure makes no sense when you
 read the code, suspect the build before you suspect the code: remove the object
 files in question and any pre-compiled headers (`*.gch`), or do

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -290,6 +290,14 @@ To update the primary bootstrap you do like this:
 ./otp_build update_primary [--no-commit]
 ```
 
+There is one situation where you have to update the primary bootstrap even
+though you are not extending the language: when you want to build Erlang/OTP
+*with* a compiler change in order to validate it. Until the bootstrap is
+updated, `make` uses the committed compiler from before your change, so the
+build succeeds without your change ever having been used. The same applies to
+[erts/preloaded/src](../erts/preloaded/src) and `update_preloaded`. Use
+`--no-commit` and drop the change again before you submit.
+
 *NOTE*: When submitting a PR to Erlang/OTP you will be asked to not include
 any commit updating preloaded or the primary bootstrap. This is because we
 cannot review the contents of binary files and thus cannot make sure they do
@@ -346,6 +354,18 @@ make emulator_test TYPE=debug
 *NOTE*: Before you run tests using a TYPE or FLAVOR you need to build the **entire**
 Erlang/OTP repo using that TYPE or FLAVOR. That is `make TYPE=debug` for the example
 above.
+
+*WARNING*: A TYPE that is not one of the recognized values is silently treated
+as `opt`, so a misspelled TYPE gives you a successful build of the wrong
+emulator. Each type and flavor is also a separate binary, and a later plain
+`make` only rebuilds the default one. Before you rely on a debug assertion or on
+a measurement, check what you are actually running:
+
+```bash
+bin/cerl -debug -noshell \
+  -eval 'io:format("~p ~p~n",[erlang:system_info(build_type),
+                              erlang:system_info(emu_flavor)]),halt().'
+```
 
 ### cerl
 

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -450,14 +450,19 @@ what Github Actions runs. `reuse lint` is a different tool with a different
 scope and will report the whole repository as non-compliant. See
 [FILE-HEADERS.md](FILE-HEADERS.md).
 
-*NOTE*: `make format-check` runs whichever `clang-format` is first in your path,
-and so does the check in Github Actions. Different versions of `clang-format`
-disagree about where to break lines, so a sweep made with one version can
-produce differences that another version rejects. Format the lines you have
-changed rather than whole files, and if you do need to reformat a file, use the
-same version as the one in the [docker image](#using-docker) that Github Actions
-uses. Note also that `git clang-format` exits with a non-zero status when it
-modifies files, which silently ends an `&&` chain.
+*NOTE*: Different major versions of `clang-format` disagree about where to break
+lines, so formatting with one version and checking with another shows up as
+changes to lines you never touched. `make format-check` and `make format`
+therefore refuse to run unless `clang-format` is the major version recorded in
+`make/clang_format_vsn`, which is the version Github Actions uses. If that
+version is not the first one in your path, point at it explicitly:
+
+```bash
+make -C erts/emulator format-check CLANG_FORMAT=clang-format-14
+```
+
+Note also that `git clang-format` exits with a non-zero status when it modifies
+files, which silently ends an `&&` chain.
 
 ## When the build lies to you
 

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -358,11 +358,10 @@ make emulator_test TYPE=debug
 Erlang/OTP repo using that TYPE or FLAVOR. That is `make TYPE=debug` for the example
 above.
 
-*WARNING*: A TYPE that is not one of the recognized values is silently treated
-as `opt`, so a misspelled TYPE gives you a successful build of the wrong
-emulator. Each type and flavor is also a separate binary, and a later plain
-`make` only rebuilds the default one. Before you rely on a debug assertion or on
-a measurement, check what you are actually running:
+*NOTE*: Each type and flavor is a separate binary, and a later plain `make` only
+rebuilds the default one, so the debug or asan emulator you built earlier can be
+older than your source tree without `make` saying anything. Before you rely on a
+debug assertion or on a measurement, check what you are actually running:
 
 ```bash
 bin/cerl -debug -noshell \
@@ -495,7 +494,8 @@ exercising your change. See
 is a separate binary. A plain `make` only rebuilds the default one, so your
 debug or asan emulator can be days older than your source tree while `make`
 reports success. See [Types and Flavors](#types-and-flavors) for how to check
-what you are actually running.
+which one you are running. Note that a TYPE that does not exist is rejected, so
+this is about a stale build of a real type, not a misspelled one.
 
 **Shadowed executables.** Erlang version managers put their own `erl`, `erlc`
 and `ex_doc` ahead of the ones in the source tree. When you mean to use the tree

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -423,7 +423,38 @@ From the top level of Erlang/OTP you can run:
 ```
 
 This will check that the documentation is correct, that there are no
-dialyzer errors and many more things.
+dialyzer errors and many more things. Run `./otp_build check --help` for the
+list of individual checks and the `--no-*` options that turn them off, and use
+`--tests` to limit the test suite build check to the applications you touched:
+
+```bash
+./otp_build check --tests stdlib
+```
+
+Each of these checks corresponds to a [Github Actions](#github-actions) job, and
+running them locally takes minutes where a Github Actions round trip takes
+roughly half an hour. The individual checks can also be run on their own:
+
+```bash
+scripts/license-header.es ci        # license and copyright headers
+make -C erts/emulator format-check  # clang-format, JIT sources only
+(cd lib/$APPLICATION_NAME && make dialyzer)
+git diff --check                    # whitespace errors
+```
+
+*NOTE*: The license header check is `scripts/license-header.es ci`, which is
+what Github Actions runs. `reuse lint` is a different tool with a different
+scope and will report the whole repository as non-compliant. See
+[FILE-HEADERS.md](FILE-HEADERS.md).
+
+*NOTE*: `make format-check` runs whichever `clang-format` is first in your path,
+and so does the check in Github Actions. Different versions of `clang-format`
+disagree about where to break lines, so a sweep made with one version can
+produce differences that another version rejects. Format the lines you have
+changed rather than whole files, and if you do need to reformat a file, use the
+same version as the one in the [docker image](#using-docker) that Github Actions
+uses. Note also that `git clang-format` exits with a non-zero status when it
+modifies files, which silently ends an `&&` chain.
 
 ## When the build lies to you
 
@@ -598,10 +629,38 @@ the logs of the test runs. The logs are attached to the finished run as
 `test_results`. You will find more details about why a testcase failed in
 the logs.
 
+Using the [Github CLI](https://cli.github.com):
+
+```bash
+gh run list --branch $BRANCH -R $YOUR_GITHUB_USER/otp
+gh run view $RUN_ID -R $YOUR_GITHUB_USER/otp --json status,conclusion,jobs
+gh run view $RUN_ID -R $YOUR_GITHUB_USER/otp --log-failed
+gh run download $RUN_ID -R $YOUR_GITHUB_USER/otp -n test_results
+gh run rerun $RUN_ID -R $YOUR_GITHUB_USER/otp --failed
+```
+
+After downloading `test_results`, open `make_test_dir/ct_logs/index.html` in it.
+`gh run rerun --failed` re-runs only the failed jobs and reuses the build from
+the original run, which is a lot faster than pushing again.
+
+*NOTE*: `gh` picks a repository based on the git remotes, which for a fork of
+Erlang/OTP is not necessarily your own. Pass `-R $YOUR_GITHUB_USER/otp`
+explicitly or you may be looking at runs from somewhere else.
+
+Before concluding that a change is what broke a job, look at the same job on the
+run for the parent commit. Some jobs are red for reasons that have nothing to do
+with the code, such as toolchain problems on less common platforms or API
+permissions on forks, and only the failures that are new relative to the parent
+commit are yours.
+
 ## Using Docker
 
 In order to get a reproduceable environment for building and testing you can use
-[docker](https//www.docker.com). If you are not familiar with how to use it I
+[docker](https://www.docker.com). This is also the only faithful way to check a
+change to C or C++ code before pushing it: the images build with `-Werror`
+settings and compiler versions that a plain local build does not use, so code
+that builds cleanly on your machine can still fail the corresponding Github
+Actions job. If you are not familiar with how to use it I
 would recommend [reading up a bit](https://www.docker.com/get-started) and trying
 some simple examples yourself before using it to build and test Erlang/OTP.
 

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -59,12 +59,13 @@ with.
     3. [Types and Flavors](#types-and-Flavors)
     4. [cerl](#cerl)
     5. [Static analysis](#static-analysis)
-5. [Running test cases](#running-test-cases)
-6. [Writing and building documentation](#writing-and-building-documentation)
+5. [When the build lies to you](#when-the-build-lies-to-you)
+6. [Running test cases](#running-test-cases)
+7. [Writing and building documentation](#writing-and-building-documentation)
     1. [Validating documentation](#validating-documentation)
-7. [Github Actions](#github-actions)
+8. [Github Actions](#github-actions)
     1. [Debugging github actions failures](#debugging-github-actions-failures)
-8. [Using Docker](#using-docker)
+9. [Using Docker](#using-docker)
     1. [Gidpod.io or VSCode dev container](#gitpod-io-or-vscode-dev-container)
 
 ## Short version
@@ -403,6 +404,54 @@ From the top level of Erlang/OTP you can run:
 
 This will check that the documentation is correct, that there are no
 dialyzer errors and many more things.
+
+## When the build lies to you
+
+The make system's dependency tracking is not complete, and a few build
+artifacts are committed to git rather than derived from the sources. The result
+is a class of problem where the build succeeds but does not build, or does not
+test, what you think it does. They are all easier to recognise than to debug, so
+they are collected here.
+
+**Stale object files after a header change.** Changing an `enum` member or a
+struct layout in a widely included header does not reliably rebuild every object
+file that depends on it. Freshly built objects then disagree with stale ones
+about numeric values or offsets, which shows up as assertion or crash failures
+that are impossible given the source code. If a failure makes no sense when you
+read the code, suspect the build before you suspect the code: remove the object
+files in question and any pre-compiled headers (`*.gch`), or do
+`make clean TYPE=$TYPE FLAVOR=$FLAVOR`, and build again.
+
+**A stale primary bootstrap.** The compiler in `bootstrap/` is what compiles
+Erlang/OTP. If you change `lib/compiler` and run `make`, the system is still
+compiled by the old committed compiler, so the build passes without ever
+exercising your change. See
+[Preloaded and Primary Bootstrap](#preloaded-and-primary-bootstrap).
+
+**Stale emulators of another type or flavor.** Each [type and flavor](#types-and-flavors)
+is a separate binary. A plain `make` only rebuilds the default one, so your
+debug or asan emulator can be days older than your source tree while `make`
+reports success. See [Types and Flavors](#types-and-flavors) for how to check
+what you are actually running.
+
+**A stale dialyzer PLT.** The PLT is not invalidated when the application beam
+files are rebuilt. If the warnings do not match the code, rebuild the PLT.
+
+**Shadowed executables.** Erlang version managers put their own `erl`, `erlc`
+and `ex_doc` ahead of the ones in the source tree. When you mean to use the tree
+you are developing in, put it first:
+
+```bash
+export PATH=$ERL_TOP/bin:$PATH
+```
+
+**A clean compile is not a working build.** A miscompiled module compiles
+without complaint and fails when it runs, typically while the build is using it
+to compile something else. Check that `bin/erl` still starts before you conclude
+that a compiler or emulator change is good.
+
+When more than one of these is in play at once, `git clean -Xfdq` followed by a
+full rebuild is usually faster than working out which one you hit.
 
 ## Running test cases
 

--- a/HOWTO/DOCUMENTATION.md
+++ b/HOWTO/DOCUMENTATION.md
@@ -485,6 +485,40 @@ functions are released with an Erlang/OTP release, this placeholder
 will get replaced with the actual OTP version, leading to something
 like "OTP 26.0".
 
+## Common documentation build failures
+
+The documentation is built with warnings treated as errors, so a warning from
+[ex_doc] fails the build.
+
+There is one wrinkle that makes this easy to miss: the wrapper in
+`$ERL_TOP/make/ex_doc_wrapper` turns warnings-as-errors *off* when any
+application is missing its `.app` file, that is when the repository is not
+fully built. A `make docs` in a partially built tree therefore prints the
+warnings and succeeds, while the same change fails in
+[Github Actions](DEVELOPMENT.md#github-actions). To get the same behavior
+locally, force it on:
+
+```bash
+EX_DOC_WARNINGS_AS_ERRORS=true make docs
+```
+
+Two kinds of warning come up often enough to be worth knowing about in advance:
+
+* **Links to files that are not part of the documentation.** A Markdown link to
+  a file that [ex_doc] does not publish, such as a design note or a file
+  belonging to another application, is reported as referring to a file that does
+  not exist. Refer to such files with inline code instead of a link.
+
+* **Autolinked code spans.** A code span such as `` `m:lists` `` or
+  `` `lists:reverse/1` `` is turned into a link. If the target is not part of
+  the published documentation the link cannot be resolved and a warning is
+  emitted. If the reference is intentional, add it to `skip_code_autolink_to`
+  in the application's `doc/docs.exs`.
+
+The documentation job in Github Actions finishes long before the build and test
+jobs do, so when you are only fixing documentation you can push and look at that
+job alone.
+
 [Markdown]: https://en.wikipedia.org/wiki/Markdown
 [mermaid diagrams]: https://mermaid.js.org/
 [Markdown flavor]: https://en.wikipedia.org/wiki/Markdown#Rise_and_divergence

--- a/HOWTO/DOCUMENTATION.md
+++ b/HOWTO/DOCUMENTATION.md
@@ -490,13 +490,17 @@ like "OTP 26.0".
 The documentation is built with warnings treated as errors, so a warning from
 [ex_doc] fails the build.
 
-There is one wrinkle that makes this easy to miss: the wrapper in
-`$ERL_TOP/make/ex_doc_wrapper` turns warnings-as-errors *off* when any
-application is missing its `.app` file, that is when the repository is not
-fully built. A `make docs` in a partially built tree therefore prints the
-warnings and succeeds, while the same change fails in
-[Github Actions](DEVELOPMENT.md#github-actions). To get the same behavior
-locally, force it on:
+There is one wrinkle worth knowing about: `$ERL_TOP/make/ex_doc_wrapper` turns
+warnings-as-errors *off* when an application that should have been built is
+missing its `.app` file, so that a `make docs` in a partially built repository
+does not fail. It says so on standard error when it does. Applications that have
+been disabled, either by their own `configure` or through
+`lib/SKIP-APPLICATIONS`, are not counted as missing.
+
+This means a `make docs` in a partially built repository prints warnings and
+succeeds where [Github Actions](DEVELOPMENT.md#github-actions) fails. To get the
+same behavior locally, either build the whole repository first, use
+`./otp_build check`, which does that for you, or force the check on:
 
 ```bash
 EX_DOC_WARNINGS_AS_ERRORS=true make docs

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1444,6 +1444,22 @@ ALL_SYS_SRC=$(wildcard sys/$(ERLANG_OSTYPE)/*.c) $(wildcard sys/common/*.c)
 # loadtime of the makefile and at that time these files are not generated yet.
 TARGET_SRC=$(shell find $(TARGET) $(TTF_DIR) -maxdepth 1 -name "*.c")
 
+## The source lists above are wildcards, so adding a source file does not change
+## any file that the dependency files below are generated from, and the
+## dependency files are not regenerated. A source file added after they were
+## last generated then has no header dependencies at all, and is never rebuilt
+## when a header it includes changes, which shows up much later as objects that
+## disagree about a struct layout or an enum value.
+##
+## Adding or removing a file does change the modification time of the directory
+## holding it, so depend on the directories as well. The Makefile is included
+## because the compiler flags used to generate the dependencies come from it.
+BEAM_SRC_DIRS=beam $(wildcard beam/emu)
+BEAM_CPP_SRC_DIRS=beam beam/jit beam/jit/$(JIT_ARCH)
+DRV_SRC_DIRS=drivers/common drivers/$(ERLANG_OSTYPE)
+NIF_SRC_DIRS=nifs/common nifs/$(ERLANG_OSTYPE)
+SYS_SRC_DIRS=sys/common sys/$(ERLANG_OSTYPE)
+
 # I do not want the -MG flag on windows, it does not work properly for a 
 # windows build.
 
@@ -1501,21 +1517,21 @@ ifeq ($(ERTS_USE_BUILTIN_RYU),yes)
 DEPEND_DEPS += ryu
 endif
 
-$(TTF_DIR)/src.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+$(TTF_DIR)/src.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC) Makefile $(BEAM_SRC_DIRS)
 	$(gen_verbose)
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) $(BEAM_SRC) > $@.tmp
 	$(V_at)$(SED_DEPEND) $@.tmp > $@
-$(TTF_DIR)/drv.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+$(TTF_DIR)/drv.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC) Makefile $(DRV_SRC_DIRS)
 	$(gen_verbose)
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) -DLIBSCTP=$(LIBSCTP) $(DRV_COMMON_SRC) > $@.tmp
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) -I../etc/$(ERLANG_OSTYPE) $(DRV_OSTYPE_SRC) >> $@.tmp
 	$(V_at)$(SED_DEPEND) $@.tmp > $@
-$(TTF_DIR)/nif.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+$(TTF_DIR)/nif.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC) Makefile $(NIF_SRC_DIRS)
 	$(gen_verbose)
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) $(NIF_COMMON_SRC) > $@.tmp
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) -DLIBSCTP=$(LIBSCTP) -I../etc/$(ERLANG_OSTYPE) $(NIF_OSTYPE_SRC) >> $@.tmp
 	$(V_at)$(SED_DEPEND) $@.tmp > $@
-$(TTF_DIR)/sys.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+$(TTF_DIR)/sys.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC) Makefile $(SYS_SRC_DIRS)
 	$(gen_verbose)
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) $(SYS_SRC) > $@.tmp
 	$(V_at)$(SED_DEPEND) $@.tmp > $@
@@ -1535,7 +1551,7 @@ $(TTF_DIR)/zstd.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
 	$(gen_verbose)
 	$(V_at)$(DEP_CC) $(DEP_FLAGS) $(ZSTD_SRC) > $@.tmp
 	$(V_at)$(SED_DEPEND_ZLIB) $@.tmp  > $@
-$(TTF_DIR)/jit.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
+$(TTF_DIR)/jit.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC) Makefile $(BEAM_CPP_SRC_DIRS)
 	$(gen_verbose)
 	@touch $@
 ifeq ($(JIT_ENABLED),yes)

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1586,13 +1586,39 @@ compdb:
 	clang -MJ $(TTF_DIR)/zlib.json $(COMPDB_CFLAGS) $(ZLIB_SRC) > /dev/null
 	cat $(TTF_DIR)/*.json > $(ERL_TOP)/compile_commands.json
 
-format-check:
-	clang-format --Werror --dry-run -i beam/jit/*.hpp beam/jit/*.c beam/jit/*.h \
+## Different major versions of clang-format make different line breaking
+## decisions, so formatting with one version and checking with another shows up
+## as changes to lines that were never touched. make/clang_format_vsn holds the
+## major version that Github Actions checks with; set CLANG_FORMAT to point at
+## that version if it is not the first clang-format in your path.
+CLANG_FORMAT ?= clang-format
+CLANG_FORMAT_VSN = $(shell grep -v '^//' $(ERL_TOP)/make/clang_format_vsn 2>/dev/null)
+CLANG_FORMAT_SRC = beam/jit/*.hpp beam/jit/*.c beam/jit/*.h \
             beam/jit/*.cpp beam/jit/*/*.cpp beam/jit/*/*.hpp
 
-format:
-	clang-format -i beam/jit/*.hpp beam/jit/*.c beam/jit/*.h \
-            beam/jit/*.cpp beam/jit/*/*.cpp beam/jit/*/*.hpp
+.PHONY: format format-check check-clang-format-vsn
+
+check-clang-format-vsn:
+	@vsn=`$(CLANG_FORMAT) --version 2>/dev/null | tr ' ' '\n' \
+	        | grep '^[0-9]' | head -1 | cut -d. -f1`; \
+	if test "X$$vsn" = "X"; then \
+	    echo "$(CLANG_FORMAT) not found or does not understand --version." >&2; \
+	    exit 1; \
+	elif test "X$(CLANG_FORMAT_VSN)" != "X" && \
+	     test "X$$vsn" != "X$(CLANG_FORMAT_VSN)"; then \
+	    echo "$(CLANG_FORMAT) is version $$vsn, but the sources are formatted" >&2; \
+	    echo "with clang-format $(CLANG_FORMAT_VSN) (see make/clang_format_vsn)." >&2; \
+	    echo "Using another version reformats lines you have not changed." >&2; \
+	    echo "Install clang-format $(CLANG_FORMAT_VSN) and either put it first in" >&2; \
+	    echo "your path or build with CLANG_FORMAT=clang-format-$(CLANG_FORMAT_VSN)." >&2; \
+	    exit 1; \
+	fi
+
+format-check: check-clang-format-vsn
+	$(CLANG_FORMAT) --Werror --dry-run -i $(CLANG_FORMAT_SRC)
+
+format: check-clang-format-vsn
+	$(CLANG_FORMAT) -i $(CLANG_FORMAT_SRC)
 
 ifneq ($(ERTS_SKIP_DEPEND),true)
 ifneq ($(MAKECMDGOALS),clean)

--- a/make/app_targets.mk
+++ b/make/app_targets.mk
@@ -50,12 +50,25 @@ DIA_PLT      = $(DIA_PLT_DIR)/$(APPLICATION).plt
 DIA_ANALYSIS = $(basename $(DIA_PLT)).dialyzer_analysis
 DIA_RUNTIME_DEPS = $(shell erl -noinput -eval '{ok, [{_, _, Keys}]} = file:consult(filelib:wildcard("ebin/*.app")), Deps = [hd(string:split(Deps, "-")) || Deps <- proplists:get_value(runtime_dependencies, Keys)], io:format("~ts",[lists:join(" ", Deps)]), init:stop().')
 
+## The plt is built from the beam files of the applications below, so it has to
+## be rebuilt when any of them change. Without this the plt is built once and
+## then never invalidated again, and dialyzer keeps analysing against whatever
+## the applications happened to look like when the plt was first created.
+## Applications that are not built yet contribute nothing here; the plt is built
+## from whatever is there when it is first needed.
+DIA_PLT_APP_LIST = $(sort $(DIA_PLT_APPS) $(DIA_RUNTIME_DEPS) $(DIA_DEFAULT_PLT_APPS))
+DIA_PLT_DEPS = $(wildcard $(ERL_TOP)/erts/preloaded/ebin/*.beam) \
+               $(wildcard $(foreach DIA_APP, $(DIA_PLT_APP_LIST), \
+                                    $(ERL_TOP)/lib/$(DIA_APP)/ebin/*.beam))
+
 dialyzer_plt: $(DIA_PLT)
 
 $(DIA_PLT_DIR):
 	@mkdir -p $@
 
-$(DIA_PLT): $(DIA_PLT_DIR)
+## $(DIA_PLT_DIR) is order only; the directory's timestamp changes when the plt
+## is written into it and must not by itself trigger a rebuild.
+$(DIA_PLT): $(DIA_PLT_DEPS) | $(DIA_PLT_DIR)
 	@echo "Building $(APPLICATION) plt file"
 	$(V_at)dialyzer --build_plt \
                   --output_plt $@ \

--- a/make/clang_format_vsn
+++ b/make/clang_format_vsn
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Ericsson and the Erlang/OTP contributors
+14

--- a/make/ex_doc_wrapper.in
+++ b/make/ex_doc_wrapper.in
@@ -31,11 +31,34 @@ fi
 ## This is currently used to handle search engine changes in v0.39.0
 export EX_DOC_VERSION=$($EX_DOC --version)
 
-## If EX_DOC_WARNINGS_AS_ERRORS is not explicitly turned on
-## and any .app file is missing, we turn off warnings as errors
+## If EX_DOC_WARNINGS_AS_ERRORS is not explicitly turned on and an application
+## that should have been built is missing its .app file, the repository is only
+## partially built and we turn off warnings as errors so that the build does not
+## fail.
+##
+## Applications that have been disabled never get an .app file, so they must not
+## be counted as missing. Otherwise a repository configured with for example
+## --without-javac, or simply built on a machine without a Java compiler, would
+## permanently stop treating documentation warnings as errors without saying so.
 if [ "${EX_DOC_WARNINGS_AS_ERRORS}" != "true" ]; then
-    for app in $ERL_TOP/lib/*/; do
-        if [ ! -f $app/ebin/*.app ]; then
+    SKIPPED_APPLICATIONS=" $(cat "$ERL_TOP/lib/SKIP-APPLICATIONS" 2>/dev/null | tr '\n' ' ') "
+    for app in "$ERL_TOP"/lib/*/; do
+        APPLICATION=$(basename "$app")
+
+        ## Disabled by the application's own configure
+        if [ -f "${app}SKIP" ]; then
+            continue
+        fi
+
+        ## Disabled through lib/SKIP-APPLICATIONS
+        case "${SKIPPED_APPLICATIONS}" in
+            *" ${APPLICATION} "*) continue;;
+        esac
+
+        APP_FILES=("${app}ebin"/*.app)
+        if [ ! -f "${APP_FILES[0]}" ]; then
+            echo "ex_doc_wrapper: ${APPLICATION} is not built," \
+                 "not treating ex_doc warnings as errors" >&2
             EX_DOC_WARNINGS_AS_ERRORS=false
         fi
     done

--- a/make/target.mk
+++ b/make/target.mk
@@ -67,3 +67,19 @@ ifeq ($(TARGET),)
 $(error Neither TARGET nor OVERRIDE_TARGET can be determined!)
 else
 endif
+
+# Ensure that the make variable TYPE is one that is actually built
+#
+# The makefiles that build C code treat any TYPE they do not recognize as opt,
+# so without this check a misspelled TYPE quietly produces a successful build of
+# a different emulator than the one that was asked for. An empty TYPE means opt.
+
+ERTS_BUILD_TYPES = opt debug lcnt valgrind asan gcov gprof frmptr icount
+
+ifneq ($(TYPE),)
+ifeq ($(filter $(TYPE),$(ERTS_BUILD_TYPES)),)
+$(error Unknown TYPE "$(TYPE)". Valid types are: $(ERTS_BUILD_TYPES))
+else
+endif
+else
+endif

--- a/scripts/license-header.es
+++ b/scripts/license-header.es
@@ -227,6 +227,7 @@ ci(Opts) ->
                       "lib/tools/test/crashdump_SUITE_data/ml-kem_encrypted_dump",
                       "lib/tools/test/emacs_SUITE_data/comprehensions",
                       "lib/tools/test/emacs_SUITE_data/type_specs",
+                      "make/clang_format_vsn",
                       "make/ex_doc_link",
                       "make/ex_doc.sha1sum",
                       "make/ex_doc.sha256sum",

--- a/scripts/otp_build_check
+++ b/scripts/otp_build_check
@@ -210,7 +210,7 @@ $ERL_TOP/bin/cerl -eval "erlang:halt()" || {
 }
 
 [ $format_check = no ] || {
-    clang-format --help 2>&1 >/dev/null || {
+    ${CLANG_FORMAT:-clang-format} --help 2>&1 >/dev/null || {
         fail "clang-format not installed. Use --no-format-check option to skip."
     }
 


### PR DESCRIPTION
This pull request introduces a new condensed guide for coding agents and developers, `AGENTS.md`, and improves the onboarding and contribution documentation. The changes clarify build, test, and contribution workflows, add practical advice to avoid common pitfalls, and enhance cross-referencing between guides. The updates aim to make development and contribution to the project more accessible and less error-prone, especially for new contributors or automated agents.

**Documentation improvements and new guides:**

* Added a new `AGENTS.md` file as a concise orientation and checklist for coding agents and contributors, summarizing essential development, build, testing, and contribution practices. It links to detailed guides and introduces a proposal for disclosing AI assistance in commits.
* Updated `CONTRIBUTING.md` to reference the new `AGENTS.md` as a short-form guide, and added practical tips for checking staged changes and using fixup commits during review. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R149-R151) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R171-R178)

**Build and test workflow clarifications:**

* Enhanced `HOWTO/DEVELOPMENT.md` with new sections explaining when the build system may not reflect source changes (e.g., stale bootstraps, object files, or emulators), and provided detailed instructions for running, targeting, and repeating tests. [[1]](diffhunk://#diff-5736c4b9fb97b26669829975097a1d33029c0ec28e78d7f31ed9fffd8fd297e2L62-R71) [[2]](diffhunk://#diff-5736c4b9fb97b26669829975097a1d33029c0ec28e78d7f31ed9fffd8fd297e2R296-R303) [[3]](diffhunk://#diff-5736c4b9fb97b26669829975097a1d33029c0ec28e78d7f31ed9fffd8fd297e2R361-R371) [[4]](diffhunk://#diff-5736c4b9fb97b26669829975097a1d33029c0ec28e78d7f31ed9fffd8fd297e2L405-R599)
* Added practical notes on checking which emulator binary is running, and clarified how to interpret and locate test results. [[1]](diffhunk://#diff-5736c4b9fb97b26669829975097a1d33029c0ec28e78d7f31ed9fffd8fd297e2R361-R371) [[2]](diffhunk://#diff-5736c4b9fb97b26669829975097a1d33029c0ec28e78d7f31ed9fffd8fd297e2L405-R599)

**Continuous integration and tooling guidance:**

* Documented the use of the GitHub CLI for interacting with CI runs, rerunning failed jobs, and downloading test results, including advice on avoiding confusion with repository remotes.
* Clarified the importance of running checks locally before pushing, and explained how local checks map to CI jobs, including details on license and formatting requirements.

These changes collectively streamline the developer experience, reduce common sources of error, and make the project more approachable for both humans and coding agents.